### PR TITLE
Feat#21. ErrorCode 확장 인터페이스 내 예외관련 프로퍼티 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-issue-template.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Issue template
 about: Bug issue Template
-title: "Bug#No. "
+title: "Bug. 내용"
 labels: bugfix
 assignees: RokwonK
 

--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,7 +1,7 @@
 ---
 name: Issue Template
 about: Default issue Template
-title: "Feat#No. "
+title: "Feat. 내용"
 labels: feature
 assignees: RokwonK
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ---
-title: "Feat#No. "
+title: "Feat#{이슈번호}. 내용"
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,7 @@
----
-title: "Feat#{이슈번호}. 내용"
-
----
-
+PR 타이틀 형식 - Feat#{이슈번호}. 내용
 
 ### Issue
+ 
 - close #{이슈번호}
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -107,12 +107,14 @@ AWS & Terraform 기반으로 배포. 프리티어 내에서 최대한 비용 효
   - `bugfix/#{issue}` : (버그 수정) 
   - `hotfix/#{issue}` : (긴급 수정) main 브랜치에서 생성
 - **Commit** 
-  - `[브랜치이름] {gitmoji} 메세지` : Gitmoji 기반으로 메시지 작성
+  - `{깃모지} 메세지` : Gitmoji 기반으로 메시지 작성
 
 <br />
 
 ### 🖇️ Pull Request
 PR Template 기반으로 작성
-- PR Title - 한 문장 요약
-- close #issue번호로 연결시키기
-- summary 및 주의깊게 볼 사항 작성
+- PR Title - `Feat#{issue}. 내용`
+- 본문
+  - Issue : `close #issue번호`로 이슈 연결시키기
+  - Summary : 기능/버그 요약
+  - Description : 설명이 필요한 부분 작성

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/common/exception/ApiCommonErrorCode.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/common/exception/ApiCommonErrorCode.kt
@@ -1,18 +1,12 @@
 package com.adevspoon.api.common.exception
 
-import com.adevspoon.common.dto.ErrorInfo
+
 import com.adevspoon.common.exception.AdevspoonErrorCode
 
 enum class ApiCommonErrorCode(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override val code: Int,
+    override val message: String,
 ): AdevspoonErrorCode {
     INVALID_ENUM_VALUE(400, 400_000_001, "유효하지 않은 Enum 값입니다");
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/config/AppConfig.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/config/AppConfig.kt
@@ -1,17 +1,7 @@
 package com.adevspoon.api.config
 
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.springframework.context.annotation.Bean
+
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class AppConfig {
-
-    @Bean
-    fun objectMapper(): ObjectMapper? {
-        val objectMapper = ObjectMapper()
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-        return objectMapper
-    }
-}
+class AppConfig

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/dto/request/SocialLoginRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/dto/request/SocialLoginRequest.kt
@@ -4,7 +4,6 @@ import com.adevspoon.common.enums.SocialType
 import com.adevspoon.infrastructure.oauth.dto.OAuthUserInfoRequest
 import io.swagger.v3.oas.annotations.media.Schema
 
-// TODO: Converter로 Enum값 value로 바꿀 필요있음
 data class SocialLoginRequest(
     @Schema(description = "소셜 로그인 토큰 - 카카오면 accessToken, 애플은 identityToken")
     val oauthToken: String,

--- a/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/AdevspoonErrorCode.kt
+++ b/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/AdevspoonErrorCode.kt
@@ -3,5 +3,9 @@ package com.adevspoon.common.exception
 import com.adevspoon.common.dto.ErrorInfo
 
 interface AdevspoonErrorCode {
-    fun getErrorInfo(): ErrorInfo
+    val status: Int
+    val code: Int
+    val message: String
+
+    fun getErrorInfo() = ErrorInfo(status, code, message)
 }

--- a/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/AdevspoonException.kt
+++ b/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/AdevspoonException.kt
@@ -1,15 +1,10 @@
 package com.adevspoon.common.exception
 
-import com.adevspoon.common.dto.ErrorInfo
-
 
 open class AdevspoonException(
     errorCode: AdevspoonErrorCode,
     detailReason: String? = null
-) : RuntimeException(detailReason ?: errorCode.getErrorInfo().message) {
-    val errorInfo = ErrorInfo(
-        status = errorCode.getErrorInfo().status,
-        code = errorCode.getErrorInfo().code,
-        message = detailReason ?: errorCode.getErrorInfo().message
-    )
+) : RuntimeException() {
+    val errorInfo = errorCode.getErrorInfo()
+        .apply { message = detailReason ?: message }
 }

--- a/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/AuthErrorCode.kt
+++ b/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/AuthErrorCode.kt
@@ -1,19 +1,12 @@
 package com.adevspoon.common.exception
 
-import com.adevspoon.common.dto.ErrorInfo
 
 enum class AuthErrorCode(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override val code: Int,
+    override val message: String,
 ): AdevspoonErrorCode {
     MISSING_AUTH(401, 401_000_001, "인증정보가 없습니다"),
 
     ILLEGAL_AUTH_ARGUMENT_ERROR(500, 500_000_001, "서버 내부 오류입니다. 관리자에게 문의하세요");
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }

--- a/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/CommonErrorCode.kt
+++ b/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/CommonErrorCode.kt
@@ -1,11 +1,10 @@
 package com.adevspoon.common.exception
 
-import com.adevspoon.common.dto.ErrorInfo
 
 enum class CommonErrorCode(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override val code: Int,
+    override val message: String,
 ): AdevspoonErrorCode {
     // code = {status}_{service|domain}_{num}
     BAD_REQUEST(400, 400_000_000, "잘못된 요청입니다"),
@@ -17,10 +16,4 @@ enum class CommonErrorCode(
     NOT_FOUND(404, 404_000_000, "요청 정보를 찾을 수 없습니다"),
 
     INTERNAL_SERVER_ERROR(500, 500_000_000, "서버 내부 오류입니다. 관리자에게 문의하세요");
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }

--- a/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/FileErrorCode.kt
+++ b/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/FileErrorCode.kt
@@ -1,21 +1,14 @@
 package com.adevspoon.common.exception
 
-import com.adevspoon.common.dto.ErrorInfo
 
 enum class FileErrorCode(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override val code: Int,
+    override val message: String,
 ): AdevspoonErrorCode {
     FILE_NAME_EMPTY(400, 400_000_002, "파일 이름이 존재하지 않습니다"),
     FILE_EXTENSION_EMPTY(400, 400_000_002, "파일 확장자가 존재하지 않습니다"),
     FILE_EXTENSION_NOT_SUPPORT(400, 400_000_002, "지원하지 않는 파일 확장자입니다"),
 
     RESIZE_IMAGE_FAILED(500, 500_000_002, "이미지 리사이즈에 실패했습니다");
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainCommonError.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainCommonError.kt
@@ -1,19 +1,13 @@
 package com.adevspoon.domain.common.exception
 
-import com.adevspoon.common.dto.ErrorInfo
+
 import com.adevspoon.common.exception.AdevspoonErrorCode
 
 enum class DomainCommonError(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override  val code: Int,
+    override  val message: String,
 ): AdevspoonErrorCode {
     // code = {status}_{service|domain}_{num}
     INVALID_ATTRIBUTE(500, 500_000_001, "유효하지 않은 값 사용");
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainErrorCode.kt
@@ -1,20 +1,13 @@
 package com.adevspoon.domain.member.exception
 
-import com.adevspoon.common.dto.ErrorInfo
+
 import com.adevspoon.common.exception.AdevspoonErrorCode
 
 enum class MemberDomainErrorCode(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override val code: Int,
+    override val message: String,
 ): AdevspoonErrorCode {
     MEMBER_NOT_FOUND(404, 404_001_000, "등록되지 않은 유저입니다"),
     MEMBER_BADGE_NOT_FOUND(404, 404_001_001, "발급받지 않은 뱃지 등록");
-
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
@@ -1,18 +1,12 @@
 package com.adevspoon.domain.techQuestion.exception
 
-import com.adevspoon.common.dto.ErrorInfo
+
 import com.adevspoon.common.exception.AdevspoonErrorCode
 
 enum class QuestionDomainErrorCode(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override val code: Int,
+    override val message: String,
 ): AdevspoonErrorCode {
     QUESTION_CATEGORY_NOT_FOUND(404, 404_002_000, "등록되지 않은 카테고리 등록");
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }

--- a/adevspoon-infrastructure/src/main/kotlin/com/adevspoon/infrastructure/oauth/exception/OAuthErrorCode.kt
+++ b/adevspoon-infrastructure/src/main/kotlin/com/adevspoon/infrastructure/oauth/exception/OAuthErrorCode.kt
@@ -1,12 +1,12 @@
 package com.adevspoon.infrastructure.oauth.exception
 
-import com.adevspoon.common.dto.ErrorInfo
+
 import com.adevspoon.common.exception.AdevspoonErrorCode
 
 enum class OAuthErrorCode(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override val code: Int,
+    override val message: String,
 ): AdevspoonErrorCode {
     KAKAO_TOKEN_EMPTY(400, 400_999_000, "카카오 토큰 없음"),
     APPLE_TOKEN_EMPTY(400, 400_999_000, "애플 토큰 없음"),
@@ -17,10 +17,4 @@ enum class OAuthErrorCode(
 
     KAKAO_SERVER_ERROR(500, 500_999_000, "카카오서버 오류"),
     APPLE_SERVER_ERROR(500, 500_999_000, "애플서버 오류");
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }

--- a/adevspoon-infrastructure/src/main/kotlin/com/adevspoon/infrastructure/storage/exception/StorageErrorCode.kt
+++ b/adevspoon-infrastructure/src/main/kotlin/com/adevspoon/infrastructure/storage/exception/StorageErrorCode.kt
@@ -1,18 +1,12 @@
 package com.adevspoon.infrastructure.storage.exception
 
-import com.adevspoon.common.dto.ErrorInfo
+
 import com.adevspoon.common.exception.AdevspoonErrorCode
 
 enum class StorageErrorCode(
-    private val status: Int,
-    private val code: Int,
-    private val message: String,
+    override val status: Int,
+    override val code: Int,
+    override val message: String,
 ): AdevspoonErrorCode {
     S3_UPLOAD_ERROR(500, 500_998_000, "버킷 업로드 실패");
-
-    override fun getErrorInfo() = ErrorInfo(
-        status = status,
-        code = code,
-        message = message
-    )
 }


### PR DESCRIPTION
### Issue
- close #21
- close #23

### Summary
- Issue/Bug/PR Template 수정 & README 추가
- 확장성 있는 예외관리를위한 AdevspoonErrorCode 및 ErrorCode 수정


### Description
이전
- 기존 AdevspoonErrorCode는 모든 ErrorCode들이 상속받아야하는 인터페이스로 예외정보를 가져올 수 있는 메서드를 가지고 있었음.
- 각 ErrorCode Enum들에서 값 별로 정보(status, code, message)를 가지고 예외정보를 넘겨주는 메서드를 직접 구현해야함. 같은 로직의 메서드를 직접 구현하는 반복적인 작업이 존재

이후
- AdevspoonErrorCode 인터페이스에서 정보(status, code, message) 프로퍼티를 가지고 이를 이용해 예외정보를 만들어주는 메서드를 직접 구현함
- 각 ErrorCode Enum들에서는 정보 프로퍼티만 override 하면됨. 반복작업(예외정보 리턴하는 메서드) 제거
