### PR TITLE
Feat/#26. 게시판 전체 태그 리스트 조회 API

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
@@ -5,27 +5,26 @@ import com.adevspoon.api.board.dto.response.BoardInfoResponse
 import com.adevspoon.api.board.dto.response.BoardListResponse
 import com.adevspoon.api.board.dto.response.BoardTagResponse
 import com.adevspoon.api.board.service.BoardService
+import com.adevspoon.api.board.service.BoardTagService
 import com.adevspoon.api.common.annotation.RequestUser
 import com.adevspoon.api.common.dto.RequestUserInfo
 import com.adevspoon.api.config.swagger.SWAGGER_TAG_BOARD
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
-import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/board")
 @Tag(name = SWAGGER_TAG_BOARD)
 class BoardController(
+    private val boardTagService: BoardTagService,
     private val boardService: BoardService
 ) {
     @Operation(summary = "게시판 전체 태그 리스트 조회")
     @GetMapping("/tag")
-    fun getBoardTagList(): BoardTagResponse {
-        TODO("""
-            게시판 전체 태그 리스트 조회
-        """.trimIndent())
+    fun getBoardTagList(): List<BoardTagResponse> {
+        return boardTagService.getBoardTagResponses()
     }
 
     @Operation(summary = "게시글 등록")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardTagService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardTagService.kt
@@ -1,0 +1,14 @@
+package com.adevspoon.api.board.service
+
+import com.adevspoon.api.board.dto.response.BoardTagResponse
+import com.adevspoon.api.common.annotation.ApplicationService
+import com.adevspoon.domain.board.service.BoardTagDomainService
+
+@ApplicationService
+class BoardTagService(
+    private val boardTagDomainService: BoardTagDomainService
+) {
+    fun getBoardTagResponses() : List<BoardTagResponse>{
+        return boardTagDomainService.getBoardTags().map { entity -> BoardTagResponse.from(entity) }
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
@@ -1,13 +1,11 @@
 package com.adevspoon.domain.board.service
 
-import com.adevspoon.domain.common.annotation.DomainService
-import com.adevspoon.domain.member.exception.MemberNotFoundException
-import com.adevspoon.domain.member.repository.UserRepository
 import com.adevspoon.domain.board.domain.BoardPostEntity
 import com.adevspoon.domain.board.dto.response.BoardPost
 import com.adevspoon.domain.board.exception.BoardTageNotFoundException
 import com.adevspoon.domain.board.repository.BoardPostRepository
 import com.adevspoon.domain.board.repository.BoardTagRepository
+import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.member.service.MemberDomainService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
@@ -15,14 +13,12 @@ import org.springframework.transaction.annotation.Transactional
 @DomainService
 class BoardPostDomainService(
     val memberDomainService: MemberDomainService,
-    val userRepository: UserRepository,
     val boardPostRepository: BoardPostRepository,
     val boardTagRepository: BoardTagRepository,
 ) {
     @Transactional
     fun registerBoardPost(userId: Long, tagId: Int, title: String, content: String): BoardPost {
-        // FIXME: userId로 user를 호출하는 방안 검토
-        val user = userRepository.findByIdOrNull(userId) ?: throw MemberNotFoundException()
+        val user = memberDomainService.getUserEntity(userId)
         val memberProfile = memberDomainService.getMemberProfile(userId)
         val tag = boardTagRepository.findByIdOrNull(tagId) ?: throw BoardTageNotFoundException()
         val boardPost = BoardPostEntity(user = user, tag = tag, title = title, content = content, likeCount = 0, commentCount = 0, viewCount = 0)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardTagDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardTagDomainService.kt
@@ -1,0 +1,14 @@
+package com.adevspoon.domain.board.service
+
+import com.adevspoon.domain.board.domain.BoardTagEntity
+import com.adevspoon.domain.board.repository.BoardTagRepository
+import com.adevspoon.domain.common.annotation.DomainService
+
+@DomainService
+class BoardTagDomainService(
+    private val boardTagRepository: BoardTagRepository
+) {
+    fun getBoardTags(): List<BoardTagEntity> {
+        return boardTagRepository.findAll()
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardTagDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardTagDomainService.kt
@@ -3,11 +3,13 @@ package com.adevspoon.domain.board.service
 import com.adevspoon.domain.board.domain.BoardTagEntity
 import com.adevspoon.domain.board.repository.BoardTagRepository
 import com.adevspoon.domain.common.annotation.DomainService
+import org.springframework.transaction.annotation.Transactional
 
 @DomainService
 class BoardTagDomainService(
     private val boardTagRepository: BoardTagRepository
 ) {
+    @Transactional(readOnly = true)
     fun getBoardTags(): List<BoardTagEntity> {
         return boardTagRepository.findAll()
     }


### PR DESCRIPTION
### Issue
 
- close #26

### Summary
- 게시판 전체 태그 리스트 조회

### Description
- #22 에서 getUserEntity() 분리한 것을 활용하여 BoardPostDomainService에서 userRepository 의존성 제거.
- 현재 도메인 모듈에서 BoardTag 응답 dto를 따로 만들지 않았습니다. api 모듈의 BoardTagResponse와 필드값 일치하고 BoardTagEntity와도 필드값이 일치했기 때문이에요. 다음 방안 중에 좋은 것을 알려주면 감사합니다.
  - 도메인 모듈에도 BoardTag dto 만들기.
  - 그대로 유지하기.