### PR TITLE
Feat#31. 게시판 리스트 조회 API

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
@@ -51,7 +51,7 @@ class BoardController(
         @RequestUser requestUser: RequestUserInfo,
         @Valid request: BoardListRequest,
     ): BoardListResponse {
-        return boardService.getBoardPostsByTags(request.tag, request.take, request.startId, request.targetUserId)
+        return boardService.getBoardPostsByTags(request.tag, request.take, request.startId, request.userId)
     }
 
     @Operation(summary = "게시글 수정")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
@@ -42,7 +42,7 @@ class BoardController(
         @RequestUser requestUser: RequestUserInfo,
         @PathVariable postId: Long,
     ): BoardInfoResponse {
-        return boardService.getBoardPost(requestUser.userId, postId)
+        return boardService.getBoardPost(postId)
     }
 
     @Operation(summary = "게시글 리스트 조회")
@@ -51,9 +51,7 @@ class BoardController(
         @RequestUser requestUser: RequestUserInfo,
         @Valid request: BoardListRequest,
     ): BoardListResponse {
-        TODO("""
-            게시판 글 리스트 조회
-        """.trimIndent())
+        return boardService.getBoardPostsByTags(request.tag, request.take, request.startId, request.targetUserId)
     }
 
     @Operation(summary = "게시글 수정")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
@@ -36,13 +36,13 @@ class BoardController(
         return boardService.registerBoardPost(requestUser.userId, request)
     }
 
-    @Operation(summary = "게시글 id기반 게시글 조회")
+    @Operation(summary = "게시글 id 기반 게시글 조회")
     @GetMapping("/post/{postId}")
     fun getBoardPost(
         @RequestUser requestUser: RequestUserInfo,
         @PathVariable postId: Long,
     ): BoardInfoResponse {
-        return boardService.getBoardPost(postId)
+        return boardService.getBoardPost(postId, requestUser.userId)
     }
 
     @Operation(summary = "게시글 리스트 조회")
@@ -51,7 +51,7 @@ class BoardController(
         @RequestUser requestUser: RequestUserInfo,
         @Valid request: BoardListRequest,
     ): BoardListResponse {
-        return boardService.getBoardPostsByTags(request.tag, request.take, request.startId, request.userId)
+        return boardService.getBoardPostsByTags(request.tag, request.take, request.startId, request.userId, requestUser.userId)
     }
 
     @Operation(summary = "게시글 수정")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/request/BoardListRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/request/BoardListRequest.kt
@@ -13,5 +13,5 @@ data class BoardListRequest(
     @field:Positive(message = "0보다 큰 수를 입력해주세요")
     val startId: Long? = null,
     @Schema(description = "유저 Id(게시글 작성자 Id)로 필터링", nullable = true, defaultValue = "null")
-    val targetUserId: Long?,
+    val userId: Long?,
 )

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/request/BoardListRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/request/BoardListRequest.kt
@@ -5,13 +5,13 @@ import jakarta.validation.constraints.Positive
 
 data class BoardListRequest(
     @Schema(description = "게시글 태그로 필터링 - 선택한 태그들의 id를 배열로 전달, 비어있다면 태그로 필터링 하지 않음", example = "[1, 2, 3]", nullable = true, defaultValue = "[]")
-    val tag: List<Long>,
+    val tag: List<Int>,
     @Schema(description = "가져올 게시글 갯수", nullable = true, defaultValue = "10")
     @field:Positive(message = "0보다 큰 수를 입력해주세요")
-    val take: Long = 10,
+    val take: Int = 10,
     @Schema(description = "가져올 게시글 시작 Id(이 Id보다 작은 Id의 게시글들을 가져옴), null이면 가장 최신데이터부턱 가져옴", nullable = true, defaultValue = "0")
     @field:Positive(message = "0보다 큰 수를 입력해주세요")
     val startId: Long? = null,
     @Schema(description = "유저 Id(게시글 작성자 Id)로 필터링", nullable = true, defaultValue = "null")
-    val userId: Long?,
+    val targetUserId: Long?,
 )

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/response/BoardInfoResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/response/BoardInfoResponse.kt
@@ -28,7 +28,7 @@ data class BoardInfoResponse(
             content = board.content,
             likeCount = board.likeCount,
             commentCount = board.commentCount,
-            isLiked = false,
+            isLiked = board.isLiked,
             createdAt = board.createdAt,
             updatedAt = board.updatedAt,
             user = MemberProfileResponse.from(board.user)

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/response/BoardListResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/response/BoardListResponse.kt
@@ -1,6 +1,24 @@
 package com.adevspoon.api.board.dto.response
 
+import com.adevspoon.domain.board.dto.response.BoardPost
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+
 data class BoardListResponse(
     val list: List<BoardInfoResponse>,
     val next: String?,
-)
+) {
+    companion object {
+        fun from(boardList: List<BoardPost>, nextCursorId: Long?): BoardListResponse {
+            val nextUrl = if (nextCursorId != null) {
+                ServletUriComponentsBuilder.fromCurrentRequest()
+                    .replaceQueryParam("startId", nextCursorId)
+                    .build()
+                    .toUriString()
+            } else null
+            return BoardListResponse(
+                list = boardList.map(BoardInfoResponse::from).toList(),
+                next = nextUrl
+            )
+        }
+    }
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
@@ -15,13 +15,13 @@ class BoardService(
         return BoardInfoResponse.from(boardPost)
     }
 
-    fun getBoardPost(postId: Long): BoardInfoResponse {
-        val boardPost = boardPostDomainService.getBoardPost(postId)
+    fun getBoardPost(postId: Long, userId: Long): BoardInfoResponse {
+        val boardPost = boardPostDomainService.getBoardPost(postId, userId)
         return BoardInfoResponse.from(boardPost)
     }
 
-    fun getBoardPostsByTags(tags: List<Int>, pageSize: Int, startPostId: Long?, targetUserId: Long?) : BoardListResponse  {
-        val pageWithCursor = boardPostDomainService.getBoardPostsByTags(tags, pageSize, startPostId, targetUserId)
+    fun getBoardPostsByTags(tags: List<Int>, pageSize: Int, startPostId: Long?, targetUserId: Long?, loginUserId: Long) : BoardListResponse  {
+        val pageWithCursor = boardPostDomainService.getBoardPostsWithCriteria(tags, pageSize, startPostId, targetUserId, loginUserId)
         return BoardListResponse.from(pageWithCursor.data, pageWithCursor.nextCursorId)
     }
 

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
@@ -2,6 +2,7 @@ package com.adevspoon.api.board.service
 
 import com.adevspoon.api.board.dto.request.RegisterBoardPostRequest
 import com.adevspoon.api.board.dto.response.BoardInfoResponse
+import com.adevspoon.api.board.dto.response.BoardListResponse
 import com.adevspoon.api.common.annotation.ApplicationService
 import com.adevspoon.domain.board.service.BoardPostDomainService
 
@@ -14,9 +15,14 @@ class BoardService(
         return BoardInfoResponse.from(boardPost)
     }
 
-    fun getBoardPost(userId: Long, postId: Long): BoardInfoResponse {
-        val boardPost = boardPostDomainService.getBoardPost(userId, postId)
+    fun getBoardPost(postId: Long): BoardInfoResponse {
+        val boardPost = boardPostDomainService.getBoardPost(postId)
         return BoardInfoResponse.from(boardPost)
+    }
+
+    fun getBoardPostsByTags(tags: List<Int>, pageSize: Int, startPostId: Long?, targetUserId: Long?) : BoardListResponse  {
+        val pageWithCursor = boardPostDomainService.getBoardPostsByTags(tags, pageSize, startPostId, targetUserId)
+        return BoardListResponse.from(pageWithCursor.data, pageWithCursor.nextCursorId)
     }
 
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardPostEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardPostEntity.kt
@@ -28,26 +28,26 @@ class BoardPostEntity(
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "userId", nullable = false)
-    val user: UserEntity? = null,
+    val user: UserEntity,
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "categoryId", nullable = false)
-    var tag: BoardTagEntity? = null,
+    var tag: BoardTagEntity,
 
     @NotNull
     @Column(name = "likeCount", nullable = false)
-    var likeCount: Int? = null,
+    var likeCount: Int,
 
     @NotNull
     @Column(name = "commentCount", nullable = false)
-    var commentCount: Int? = null,
+    var commentCount: Int,
 
     @NotNull
     @Column(name = "viewCount", nullable = false)
-    var viewCount: Int? = null
+    var viewCount: Int
 ) : BaseEntity() {
     fun increaseViewCount() {
-        this.viewCount = (this.viewCount ?: 0) + 1
+        this.viewCount++
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/dto/response/BoardPost.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/dto/response/BoardPost.kt
@@ -14,11 +14,12 @@ data class BoardPost(
     var likeCount: Int,
     var commentCount: Int,
     var viewCount: Int,
+    var isLiked: Boolean,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 ) {
     companion object {
-        fun from(board: BoardPostEntity, memberProfile: MemberProfile) = BoardPost(
+        fun from(board: BoardPostEntity, memberProfile: MemberProfile, isLiked: Boolean) = BoardPost(
             id = board.id,
             title = board.title ?: "",
             content = board.content ?: "",
@@ -27,6 +28,7 @@ data class BoardPost(
             likeCount = board.likeCount ?: 0,
             commentCount = board.commentCount ?: 0,
             viewCount = board.viewCount ?: 0,
+            isLiked = isLiked,
             createdAt = board.createdAt ?: LocalDateTime.now(),
             updatedAt = board.updatedAt ?: LocalDateTime.now()
         )

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
@@ -11,18 +11,19 @@ interface BoardPostRepository : JpaRepository<BoardPostEntity, Long> {
 
     @Query("SELECT bp FROM BoardPostEntity bp " +
         "WHERE (:startPostId IS NULL OR bp.id <= :startPostId) " +
-        "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId) " +
-        "ORDER BY bp.id DESC")
+        "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId)"
+    )
     fun findAllBoardPosts(
         @Param("startPostId") startPostId: Long?,
         @Param("targetUserId") targetUserId: Long?,
         pageable: Pageable) : Page<BoardPostEntity>
+
     @Query("SELECT bp FROM BoardPostEntity bp " +
         "JOIN bp.tag t " +
         "WHERE (:tags IS NULL OR t.id IN :tags) " +
         "AND (:startPostId IS NULL OR bp.id <= :startPostId) " +
-        "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId) " +
-        "ORDER BY bp.id DESC")
+        "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId) "
+        )
     fun findByTagsAndUserIdWitchCursor(
         @Param("tags") tags: List<Int>,
         @Param("startPostId") startPostId: Long?,

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
@@ -1,6 +1,31 @@
 package com.adevspoon.domain.board.repository
 
 import com.adevspoon.domain.board.domain.BoardPostEntity
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
-interface BoardPostRepository : JpaRepository<BoardPostEntity, Long>
+interface BoardPostRepository : JpaRepository<BoardPostEntity, Long> {
+
+    @Query("SELECT bp FROM BoardPostEntity bp " +
+        "WHERE (:startPostId IS NULL OR bp.id <= :startPostId) " +
+        "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId) " +
+        "ORDER BY bp.id DESC")
+    fun findAllBoardPosts(
+        @Param("startPostId") startPostId: Long?,
+        @Param("targetUserId") targetUserId: Long?,
+        pageable: Pageable) : Page<BoardPostEntity>
+    @Query("SELECT bp FROM BoardPostEntity bp " +
+        "JOIN bp.tag t " +
+        "WHERE (:tags IS NULL OR t.id IN :tags) " +
+        "AND (:startPostId IS NULL OR bp.id <= :startPostId) " +
+        "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId) " +
+        "ORDER BY bp.id DESC")
+    fun findByTagsAndUserIdWitchCursor(
+        @Param("tags") tags: List<Int>,
+        @Param("startPostId") startPostId: Long?,
+        @Param("targetUserId") targetUserId: Long?,
+        pageable: Pageable) : Page<BoardPostEntity>
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
@@ -10,23 +10,23 @@ import org.springframework.data.repository.query.Param
 interface BoardPostRepository : JpaRepository<BoardPostEntity, Long> {
 
     @Query("SELECT bp FROM BoardPostEntity bp " +
-        "WHERE (:startPostId IS NULL OR bp.id <= :startPostId) " +
+        "WHERE (:startPostId IS NULL OR bp.id < :startPostId) " +
         "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId)"
     )
-    fun findAllBoardPosts(
+    fun findWithNoTagsAndUserIdWithCursor(
         @Param("startPostId") startPostId: Long?,
         @Param("targetUserId") targetUserId: Long?,
         pageable: Pageable) : Page<BoardPostEntity>
 
     @Query("SELECT bp FROM BoardPostEntity bp " +
         "JOIN bp.tag t " +
-        "WHERE (:tags IS NULL OR t.id IN :tags) " +
-        "AND (:startPostId IS NULL OR bp.id <= :startPostId) " +
+        "WHERE (t.id IN :tags) " +
+        "AND (:startPostId IS NULL OR bp.id < :startPostId) " +
         "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId) "
         )
-    fun findByTagsAndUserIdWitchCursor(
+    fun findByTagsAndUserIdWithCursor(
         @Param("tags") tags: List<Int>,
         @Param("startPostId") startPostId: Long?,
         @Param("targetUserId") targetUserId: Long?,
-        pageable: Pageable) : Page<BoardPostEntity>
+        pageable: Pageable): Page<BoardPostEntity>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
@@ -45,6 +45,7 @@ class BoardPostDomainService(
         return BoardPost.from(boardPost, memberProfile)
     }
 
+    @Transactional(readOnly = true)
     fun getBoardPostsByTags(tags: List<Int>, pageSize: Int, startPostId: Long?, targetUserId: Long?): PageWithCursor<BoardPost> {
         val pageable = CursorPageable(startPostId, pageSize)
         val page = fetchPostBasedOnTageExistence(tags, startPostId, targetUserId, pageable)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
@@ -7,9 +7,9 @@ import com.adevspoon.domain.board.exception.BoardTageNotFoundException
 import com.adevspoon.domain.board.repository.BoardPostRepository
 import com.adevspoon.domain.board.repository.BoardTagRepository
 import com.adevspoon.domain.common.annotation.DomainService
+import com.adevspoon.domain.common.service.LikeDomainService
 import com.adevspoon.domain.common.utils.CursorPageable
 import com.adevspoon.domain.common.utils.PageWithCursor
-import com.adevspoon.domain.member.exception.MemberNotFoundException
 import com.adevspoon.domain.member.service.MemberDomainService
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -18,18 +18,22 @@ import org.springframework.transaction.annotation.Transactional
 
 @DomainService
 class BoardPostDomainService(
-    val memberDomainService: MemberDomainService,
     val boardPostRepository: BoardPostRepository,
     val boardTagRepository: BoardTagRepository,
+    val memberDomainService: MemberDomainService,
+    val likeDomainService: LikeDomainService
 ) {
     @Transactional
     fun registerBoardPost(userId: Long, tagId: Int, title: String, content: String): BoardPost {
         val user = memberDomainService.getUserEntity(userId)
         val memberProfile = memberDomainService.getMemberProfile(userId)
         val tag = boardTagRepository.findByIdOrNull(tagId) ?: throw BoardTageNotFoundException()
+
         val boardPost = BoardPostEntity(user = user, tag = tag, title = title, content = content, likeCount = 0, commentCount = 0, viewCount = 0)
+
         val savedBoardPost = boardPostRepository.save(boardPost)
-        return BoardPost.from(savedBoardPost, memberProfile)
+        val isUserLikedBoardPost = likeDomainService.isUserLikedPost(user.id, boardPost.id)
+        return BoardPost.from(savedBoardPost, memberProfile, isUserLikedBoardPost)
     }
 
     @Transactional
@@ -38,25 +42,29 @@ class BoardPostDomainService(
         boardPost.increaseViewCount()
         boardPostRepository.save(boardPost)
 
-        val userId = boardPost.user?.id
-        userId?.let { BoardPost.from(boardPost, memberDomainService.getMemberProfile(it)) } ?: throw MemberNotFoundException()
+        val user = boardPost.user
+        val isUserLikedBoardPost = likeDomainService.isUserLikedPost(user.id, boardPost.id)
 
-        val memberProfile = memberDomainService.getMemberProfile(userId)
-        return BoardPost.from(boardPost, memberProfile)
+        val memberProfile = memberDomainService.getMemberProfile(user.id)
+        return BoardPost.from(boardPost, memberProfile, isUserLikedBoardPost)
     }
 
     @Transactional(readOnly = true)
     fun getBoardPostsByTags(tags: List<Int>, pageSize: Int, startPostId: Long?, targetUserId: Long?): PageWithCursor<BoardPost> {
-        val pageable = CursorPageable(startPostId, pageSize)
+        val pageable = CursorPageable(pageSize)
         val page = fetchPostBasedOnTageExistence(tags, startPostId, targetUserId, pageable)
 
         val boardPosts = page.content
         val nextCursorId = if (boardPosts.size < pageSize) null else page.lastOrNull()?.id
 
+
+
+
         return PageWithCursor(
             data = boardPosts.map { boardPost ->
-                val userId = boardPost.user?.id
-                userId?.let { BoardPost.from(boardPost, memberDomainService.getMemberProfile(it)) } ?: throw MemberNotFoundException()
+                val user = boardPost.user
+                val isUserLikedBoardPost = likeDomainService.isUserLikedPost(user.id, boardPost.id)
+                BoardPost.from(boardPost, memberDomainService.getMemberProfile(user.id), isUserLikedBoardPost)
             },
             nextCursorId = nextCursorId
         )

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/entity/LikeEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/entity/LikeEntity.kt
@@ -1,7 +1,7 @@
 package com.adevspoon.domain.common.entity
 
-import com.adevspoon.domain.techQuestion.domain.AnswerEntity
 import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.techQuestion.domain.AnswerEntity
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
@@ -23,12 +23,12 @@ class LikeEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id")
-    val user: UserEntity? = null,
+    val user: UserEntity,
 
     @Size(max = 50)
     @NotNull
     @Column(name = "post_type", nullable = false, length = 50)
-    val postType: String? = null,
+    val postType: String,
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -37,7 +37,7 @@ class LikeEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "post_id")
-    val post: AnswerEntity? = null,
+    val answer: AnswerEntity? = null,
 
     @Column(name = "boardPostId")
     val boardPostId: Long? = null,

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
@@ -1,0 +1,10 @@
+package com.adevspoon.domain.common.repository
+
+import com.adevspoon.domain.common.entity.LikeEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface LikeRepository : JpaRepository<LikeEntity, Long> {
+    @Query("SELECT EXISTS (SELECT 1 FROM LikeEntity l WHERE l.user.id = :userId AND l.boardPostId = :boardPostId)")
+    fun exitsByUserIdAndBoardPostId(userId: Long, boardPostId: Long): Boolean
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
@@ -7,4 +7,7 @@ import org.springframework.data.jpa.repository.Query
 interface LikeRepository : JpaRepository<LikeEntity, Long> {
     @Query("SELECT EXISTS (SELECT 1 FROM LikeEntity l WHERE l.user.id = :userId AND l.boardPostId = :boardPostId)")
     fun exitsByUserIdAndBoardPostId(userId: Long, boardPostId: Long): Boolean
+
+    @Query("SELECT l.boardPostId FROM LikeEntity l WHERE l.user.id = :loginUserId AND l.boardPostId In :boardPostIds")
+    fun findLikedPostIdsByUser(loginUserId: Long, boardPostIds: List<Long>): List<Long>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
@@ -11,4 +11,8 @@ class LikeDomainService (
         return likeRepository.exitsByUserIdAndBoardPostId(userId, boardPostId)
     }
 
+    fun getLikedPostIdsByUser(loginUserId: Long, boardPostIds: List<Long>): List<Long> {
+        return likeRepository.findLikedPostIdsByUser(loginUserId, boardPostIds)
+    }
+
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
@@ -1,0 +1,14 @@
+package com.adevspoon.domain.common.service
+
+import com.adevspoon.domain.common.annotation.DomainService
+import com.adevspoon.domain.common.repository.LikeRepository
+
+@DomainService
+class LikeDomainService (
+    private val likeRepository: LikeRepository
+){
+    fun isUserLikedPost(userId: Long, boardPostId: Long) : Boolean {
+        return likeRepository.exitsByUserIdAndBoardPostId(userId, boardPostId)
+    }
+
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/utils/CursorPageable.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/utils/CursorPageable.kt
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 
 data class CursorPageable(
-    private val cursorId: Long?,
     private val size: Int,
     private val sort: Sort? = Sort.by(Sort.Direction.DESC, "id")
 ) : Pageable{

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/utils/CursorPageable.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/utils/CursorPageable.kt
@@ -1,0 +1,34 @@
+package com.adevspoon.domain.common.utils
+
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+
+data class CursorPageable(
+    private val cursorId: Long?,
+    private val size: Int,
+    private val sort: Sort? = Sort.by(Sort.Direction.DESC, "id")
+) : Pageable{
+    override fun getPageNumber(): Int = 0 // no user pageNumber
+
+    override fun getPageSize(): Int = size
+
+    override fun getOffset(): Long = 0 // no user offSet
+
+    override fun getSort(): Sort = sort ?: Sort.by(Sort.Direction.DESC, "id")
+
+    override fun next(): Pageable {
+        throw UnsupportedOperationException("Cursor based navigation does not support this operation.")
+    }
+
+    override fun previousOrFirst(): Pageable {
+        throw UnsupportedOperationException("Cursor based navigation does not support this operation.")
+    }
+
+    override fun first(): Pageable = this
+
+    override fun withPage(pageNumber: Int): Pageable {
+        throw UnsupportedOperationException("Cursor based navigation does not support this operation.")
+    }
+
+    override fun hasPrevious(): Boolean = false
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/utils/PageWithCursor.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/utils/PageWithCursor.kt
@@ -1,0 +1,6 @@
+package com.adevspoon.domain.common.utils
+
+class PageWithCursor<T> (
+    val data: List<T>,
+    val nextCursorId: Long?
+)


### PR DESCRIPTION
### Issue
 
- close #31

### Summary
- 태그 별로(여러개 태그 가능) 게시판 리스트 조회
- 태그가 존재하지 않으면 전체 태그로 간주하고 게시판 리스트 조회

### Description
- 게시판 리스트 조회 request에 태그 리스트 타입을 Long에서 Int로 바꿨습니다. Tag 엔티티는 Int로 되어있기 때문입니다.
- CursorPage를 커스터마이징 했습니다
- 응답에 다음 커서로 이동하기 위한 url을 등록했습니다.
- 만약 마지막 페이지라면 다음 커서로 이동하기 위한 url은 null로 되어 응답값에 포함되지 않습니다.