### PR TITLE
Feat/#15. 질문 발급 및 조회 API &분산락 구현

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionListRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionListRequest.kt
@@ -3,7 +3,6 @@ package com.adevspoon.api.question.dto.request
 import io.swagger.v3.oas.annotations.media.Schema
 
 
-// TODO: Enum Validate, Converter 필요
 data class QuestionListRequest(
     val sort: QuestionSortType = QuestionSortType.NEWEST,
     @Schema(description = "등록한 답변만 가져올것인지 여부")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionRequest.kt
@@ -1,0 +1,6 @@
+package com.adevspoon.api.question.dto.request
+
+data class QuestionRequest(
+    val questionId: Long?,
+    val type: String = "today",
+)

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/response/QuestionInfoResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/response/QuestionInfoResponse.kt
@@ -1,5 +1,6 @@
 package com.adevspoon.api.question.dto.response
 
+import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
@@ -18,7 +19,7 @@ data class QuestionInfoResponse(
     @JsonProperty("study_link")
     val studyLink: String,
 
-    @Schema(description = "해당 질문의 카테고리 이름")
+    @Schema(description = "해당 질문의 카테고리 이름", example = "알고리즘")
     @JsonProperty("category")
     val categoryName: String,
 
@@ -29,7 +30,7 @@ data class QuestionInfoResponse(
     val updatedAt: LocalDateTime,
 
     @Schema(description = "해당 질문에 대한 태그 리스트, 현재는 사용되지 않음")
-    val tag: List<String>,
+    val tag: List<String>? = null,
 
     @Schema(description = "질문을 발급받은 날짜", example = "2021-01-01")
     @JsonProperty("open_date")
@@ -41,4 +42,20 @@ data class QuestionInfoResponse(
 
     @Schema(description = "해당 카테고리에 더 이상 받을 질문이 없는지 여부")
     val isLast: Boolean = false,
-)
+) {
+    companion object {
+        fun from(info: QuestionInfo) = QuestionInfoResponse(
+            questionId = info.questionId,
+            question = info.question,
+            difficulty = info.difficulty,
+            studyLink = info.studyLink,
+            categoryName = info.categoryName,
+            createdAt = info.createdAt,
+            updatedAt = info.updatedAt,
+            tag = info.tag,
+            openDate = info.openDate,
+            answerId = info.answerId,
+            isLast = info.isLast,
+        )
+    }
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
@@ -1,0 +1,25 @@
+package com.adevspoon.api.question.service
+
+import com.adevspoon.api.common.annotation.ApplicationService
+import com.adevspoon.api.question.dto.response.QuestionInfoResponse
+import com.adevspoon.domain.techQuestion.service.QuestionDomainService
+import java.time.LocalDate
+
+@ApplicationService
+class QuestionService(
+    private val questionDomainService: QuestionDomainService
+) {
+    fun getTodayQuestion(memberId: Long): QuestionInfoResponse {
+        return questionDomainService.getOrCreateTodayQuestion(memberId, LocalDate.now())
+            .let {
+                QuestionInfoResponse.from(it)
+            }
+    }
+
+    fun getQuestionById(memberId: Long, questionId: Long): QuestionInfoResponse {
+        return questionDomainService.getQuestion(memberId, questionId)
+            .let {
+                QuestionInfoResponse.from(it)
+            }
+    }
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
@@ -2,6 +2,7 @@ package com.adevspoon.api.question.service
 
 import com.adevspoon.api.common.annotation.ApplicationService
 import com.adevspoon.api.question.dto.response.QuestionInfoResponse
+import com.adevspoon.domain.techQuestion.dto.request.GetTodayQuestion
 import com.adevspoon.domain.techQuestion.service.QuestionDomainService
 import java.time.LocalDate
 
@@ -10,7 +11,7 @@ class QuestionService(
     private val questionDomainService: QuestionDomainService
 ) {
     fun getTodayQuestion(memberId: Long): QuestionInfoResponse {
-        return questionDomainService.getOrCreateTodayQuestion(memberId, LocalDate.now())
+        return questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(memberId, LocalDate.now()))
             .let {
                 QuestionInfoResponse.from(it)
             }

--- a/adevspoon-common/src/main/kotlin/com/adevspoon/common/dto/ErrorInfo.kt
+++ b/adevspoon-common/src/main/kotlin/com/adevspoon/common/dto/ErrorInfo.kt
@@ -4,4 +4,5 @@ data class ErrorInfo(
     val status: Int, // HTTP status code
     val code: Int, // error code
     var message: String, // error message
+    var log: String? = null // log message
 )

--- a/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/AdevspoonException.kt
+++ b/adevspoon-common/src/main/kotlin/com/adevspoon/common/exception/AdevspoonException.kt
@@ -3,8 +3,12 @@ package com.adevspoon.common.exception
 
 abstract class AdevspoonException(
     errorCode: AdevspoonErrorCode,
-    detailReason: String? = null
+    detailReason: String? = null,
+    internalLog: String? = null
 ) : RuntimeException() {
     val errorInfo = errorCode.errorInfo
-        .apply { message = detailReason ?: message }
+        .apply {
+            message = detailReason ?: message
+            log = internalLog
+        }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/annotation/DistributedLock.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/annotation/DistributedLock.kt
@@ -1,0 +1,13 @@
+package com.adevspoon.domain.common.annotation
+
+import com.adevspoon.domain.common.lock.DistributedLockKey
+import org.springframework.core.annotation.Order
+import kotlin.reflect.KClass
+
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Order(1)
+annotation class DistributedLock(
+    val keyClass: Array<KClass<out DistributedLockKey>> = [],
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/annotation/DistributedLock.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/annotation/DistributedLock.kt
@@ -1,13 +1,11 @@
 package com.adevspoon.domain.common.annotation
 
-import com.adevspoon.domain.common.lock.DistributedLockKey
-import org.springframework.core.annotation.Order
+import com.adevspoon.domain.common.lock.LockKey
 import kotlin.reflect.KClass
 
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-@Order(1)
 annotation class DistributedLock(
-    val keyClass: Array<KClass<out DistributedLockKey>> = [],
+    val keyClass: Array<KClass<out LockKey>> = [],
 )

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/annotation/LockDataSource.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/annotation/LockDataSource.kt
@@ -1,0 +1,9 @@
+package com.adevspoon.domain.common.annotation
+
+import org.springframework.beans.factory.annotation.Qualifier
+
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Qualifier("lockDataSource")
+annotation class LockDataSource()

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/aop/DistributedLockAdvisor.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/aop/DistributedLockAdvisor.kt
@@ -1,0 +1,46 @@
+package com.adevspoon.domain.common.aop
+
+import com.adevspoon.domain.common.annotation.DistributedLock
+import com.adevspoon.domain.common.exception.DomainFailToGetLockException
+import com.adevspoon.domain.common.lock.DistributedLockKey
+import com.adevspoon.domain.common.lock.DistributedLockRepository
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import kotlin.reflect.KClass
+
+@Aspect
+@Component
+class DistributedLockAdvisor(
+    private val lockRepository: DistributedLockRepository
+) {
+    val logger: Logger = LoggerFactory.getLogger(this.javaClass)
+
+    @Around("@annotation(com.adevspoon.domain.common.annotation.DistributedLock)")
+    fun atTarget(joinPoint: ProceedingJoinPoint): Any? {
+        val lockAnnotation = (joinPoint.signature as MethodSignature).method
+            .getAnnotation(DistributedLock::class.java)
+        val lockKeyList = getLockKeyList(joinPoint.args, lockAnnotation.keyClass)
+
+        try {
+            lockKeyList.map { lockRepository.getLock(it.lockKey, it.timeout, it.leaseTime) }
+                .filter { !it }
+                .takeIf { it.isEmpty() }
+                ?: throw DomainFailToGetLockException()
+            logger.info("DistributedLock Get : ${lockKeyList.joinToString(", ") { it.lockKey }}")
+            return joinPoint.proceed()
+        } finally {
+            logger.info("DistributedLock Release : ${lockKeyList.joinToString(", ") { it.lockKey }}")
+            lockKeyList.forEach { lockRepository.releaseLock(it.lockKey) }
+        }
+    }
+
+    private fun getLockKeyList(arguments: Array<Any>, keyClasses: Array<KClass<out DistributedLockKey>>) =
+        arguments.filterIsInstance<DistributedLockKey>()
+            .filter { keyClasses.isEmpty() || keyClasses.contains(it::class) }
+            .toList()
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/aop/DistributedLockAdvisor.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/aop/DistributedLockAdvisor.kt
@@ -1,46 +1,41 @@
 package com.adevspoon.domain.common.aop
 
 import com.adevspoon.domain.common.annotation.DistributedLock
-import com.adevspoon.domain.common.exception.DomainFailToGetLockException
-import com.adevspoon.domain.common.lock.DistributedLockKey
-import com.adevspoon.domain.common.lock.DistributedLockRepository
+import com.adevspoon.domain.common.exception.DomainLockKeyNotSetException
+import com.adevspoon.domain.common.lock.LockKey
+import com.adevspoon.domain.common.lock.interfaces.DistributedLockRepository
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 import kotlin.reflect.KClass
 
 @Aspect
 @Component
+@Order(1)
 class DistributedLockAdvisor(
     private val lockRepository: DistributedLockRepository
 ) {
-    val logger: Logger = LoggerFactory.getLogger(this.javaClass)
-
     @Around("@annotation(com.adevspoon.domain.common.annotation.DistributedLock)")
     fun atTarget(joinPoint: ProceedingJoinPoint): Any? {
-        val lockAnnotation = (joinPoint.signature as MethodSignature).method
-            .getAnnotation(DistributedLock::class.java)
+        val lockAnnotation = getAnnotation(joinPoint)
         val lockKeyList = getLockKeyList(joinPoint.args, lockAnnotation.keyClass)
 
-        try {
-            lockKeyList.map { lockRepository.getLock(it.lockKey, it.timeout, it.leaseTime) }
-                .filter { !it }
-                .takeIf { it.isEmpty() }
-                ?: throw DomainFailToGetLockException()
-            logger.info("DistributedLock Get : ${lockKeyList.joinToString(", ") { it.lockKey }}")
-            return joinPoint.proceed()
-        } finally {
-            logger.info("DistributedLock Release : ${lockKeyList.joinToString(", ") { it.lockKey }}")
-            lockKeyList.forEach { lockRepository.releaseLock(it.lockKey) }
+        return lockRepository.withAllLock(lockKeyList) {
+            joinPoint.proceed()
         }
     }
 
-    private fun getLockKeyList(arguments: Array<Any>, keyClasses: Array<KClass<out DistributedLockKey>>) =
-        arguments.filterIsInstance<DistributedLockKey>()
+    private fun getAnnotation(joinPoint: ProceedingJoinPoint) =
+        (joinPoint.signature as MethodSignature).method
+            .getAnnotation(DistributedLock::class.java)
+
+    private fun getLockKeyList(arguments: Array<Any>, keyClasses: Array<KClass<out LockKey>>) =
+        arguments.filterIsInstance<LockKey>()
             .filter { keyClasses.isEmpty() || keyClasses.contains(it::class) }
             .toList()
+            .takeIf { it.isNotEmpty() }
+            ?: throw DomainLockKeyNotSetException()
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainCommonError.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainCommonError.kt
@@ -8,5 +8,7 @@ enum class DomainCommonError(
     override val error: DomainType.Error,
     override val message: String,
 ): AdevspoonErrorCode {
-    INVALID_ATTRIBUTE(DomainType.COMMON code 500 no 1, "유효하지 않은 값 사용");
+    INVALID_ATTRIBUTE(DomainType.COMMON code 500 no 1, "유효하지 않은 값 사용"),
+
+    FAIL_TO_GET_LOCK(DomainType.COMMON code 500 no 2, "서버 내부 오류입니다. 관리자에게 문의하세요");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainCommonError.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainCommonError.kt
@@ -10,5 +10,7 @@ enum class DomainCommonError(
 ): AdevspoonErrorCode {
     INVALID_ATTRIBUTE(DomainType.COMMON code 500 no 1, "유효하지 않은 값 사용"),
 
-    FAIL_TO_GET_LOCK(DomainType.COMMON code 500 no 2, "서버 내부 오류입니다. 관리자에게 문의하세요");
+    FAIL_TO_GET_LOCK(DomainType.COMMON code 500 no 2, "서버 내부 오류입니다. 관리자에게 문의하세요"),
+    FAIL_TO_RELEASE_LOCK(DomainType.COMMON code 500 no 3, "서버 내부 오류입니다. 관리자에게 문의하세요"),
+    LOCK_KEY_NOT_SET(DomainType.COMMON code 500 no 4, "서버 내부 오류입니다. 관리자에게 문의하세요");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainCommonError.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainCommonError.kt
@@ -10,7 +10,8 @@ enum class DomainCommonError(
 ): AdevspoonErrorCode {
     INVALID_ATTRIBUTE(DomainType.COMMON code 500 no 1, "유효하지 않은 값 사용"),
 
-    FAIL_TO_GET_LOCK(DomainType.COMMON code 500 no 2, "서버 내부 오류입니다. 관리자에게 문의하세요"),
-    FAIL_TO_RELEASE_LOCK(DomainType.COMMON code 500 no 3, "서버 내부 오류입니다. 관리자에게 문의하세요"),
-    LOCK_KEY_NOT_SET(DomainType.COMMON code 500 no 4, "서버 내부 오류입니다. 관리자에게 문의하세요");
+    FAIL_TO_LOCK_QUERY(DomainType.COMMON code 500 no 2, "서버 내부 오류입니다. 관리자에게 문의하세요"),
+    FAIL_TO_GET_LOCK(DomainType.COMMON code 500 no 3, "서버 내부 오류입니다. 관리자에게 문의하세요"),
+    FAIL_TO_RELEASE_LOCK(DomainType.COMMON code 500 no 4, "서버 내부 오류입니다. 관리자에게 문의하세요"),
+    LOCK_KEY_NOT_SET(DomainType.COMMON code 500 no 5, "서버 내부 오류입니다. 관리자에게 문의하세요");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainException.kt
@@ -3,4 +3,6 @@ package com.adevspoon.domain.common.exception
 import com.adevspoon.common.exception.AdevspoonException
 
 class DomainInvalidAttributeException(type: String? = null): AdevspoonException(DomainCommonError.INVALID_ATTRIBUTE, type?.let { "$it 타입 필드에 유효하지 않은 값이 들어갔습니다" })
-class DomainFailToGetLockException: AdevspoonException(DomainCommonError.FAIL_TO_GET_LOCK)
+class DomainFailToGetLockException(keyName: String? = null, reason: String? = null): AdevspoonException(DomainCommonError.FAIL_TO_GET_LOCK, internalLog = keyName?.let { "$it 획득 실패 (사유: $reason)" })
+class DomainFailToReleaseLockException(keyName: String? = null, reason: String? = null): AdevspoonException(DomainCommonError.FAIL_TO_RELEASE_LOCK, internalLog = keyName?.let { "$it 해제 실패 (사유: $reason)" })
+class DomainLockKeyNotSetException: AdevspoonException(DomainCommonError.LOCK_KEY_NOT_SET)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainException.kt
@@ -3,3 +3,4 @@ package com.adevspoon.domain.common.exception
 import com.adevspoon.common.exception.AdevspoonException
 
 class DomainInvalidAttributeException(type: String? = null): AdevspoonException(DomainCommonError.INVALID_ATTRIBUTE, type?.let { "$it 타입 필드에 유효하지 않은 값이 들어갔습니다" })
+class DomainFailToGetLockException: AdevspoonException(DomainCommonError.FAIL_TO_GET_LOCK)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/exception/DomainException.kt
@@ -3,6 +3,7 @@ package com.adevspoon.domain.common.exception
 import com.adevspoon.common.exception.AdevspoonException
 
 class DomainInvalidAttributeException(type: String? = null): AdevspoonException(DomainCommonError.INVALID_ATTRIBUTE, type?.let { "$it 타입 필드에 유효하지 않은 값이 들어갔습니다" })
+class DomainFailToLockQueryException: AdevspoonException(DomainCommonError.FAIL_TO_LOCK_QUERY)
 class DomainFailToGetLockException(keyName: String? = null, reason: String? = null): AdevspoonException(DomainCommonError.FAIL_TO_GET_LOCK, internalLog = keyName?.let { "$it 획득 실패 (사유: $reason)" })
 class DomainFailToReleaseLockException(keyName: String? = null, reason: String? = null): AdevspoonException(DomainCommonError.FAIL_TO_RELEASE_LOCK, internalLog = keyName?.let { "$it 해제 실패 (사유: $reason)" })
 class DomainLockKeyNotSetException: AdevspoonException(DomainCommonError.LOCK_KEY_NOT_SET)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/DistributedLockKey.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/DistributedLockKey.kt
@@ -1,0 +1,19 @@
+package com.adevspoon.domain.common.lock
+
+private const val PREFIX_ISSUE_QUESTION = "issue_question:"
+
+
+sealed interface DistributedLockKey {
+    val lockKey: String
+    val timeout: Int
+        get() = 3
+    val leaseTime: Int
+        get() = -1
+}
+
+interface IssueQuestionLockKey : DistributedLockKey {
+    val keyMemberId: Long
+
+    override val lockKey: String
+        get() = "$PREFIX_ISSUE_QUESTION:$keyMemberId"
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/DistributedLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/DistributedLockRepository.kt
@@ -1,0 +1,6 @@
+package com.adevspoon.domain.common.lock
+
+interface DistributedLockRepository {
+    fun getLock(lockKey: String, timeout: Int, leaseTime: Int = -1): Boolean
+    fun releaseLock(lockKey: String): Boolean
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/DistributedLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/DistributedLockRepository.kt
@@ -1,6 +1,0 @@
-package com.adevspoon.domain.common.lock
-
-interface DistributedLockRepository {
-    fun getLock(lockKey: String, timeout: Int, leaseTime: Int = -1): Boolean
-    fun releaseLock(lockKey: String): Boolean
-}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/LockKey.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/LockKey.kt
@@ -1,19 +1,19 @@
 package com.adevspoon.domain.common.lock
 
-private const val PREFIX_ISSUE_QUESTION = "issue_question:"
+private const val PREFIX_ISSUE_QUESTION = "issue_question"
 
 
-sealed interface DistributedLockKey {
-    val lockKey: String
+sealed interface LockKey {
+    val name: String
     val timeout: Int
         get() = 3
     val leaseTime: Int
         get() = -1
 }
 
-interface IssueQuestionLockKey : DistributedLockKey {
+interface IssueQuestionLockKey : LockKey {
     val keyMemberId: Long
 
-    override val lockKey: String
+    override val name: String
         get() = "$PREFIX_ISSUE_QUESTION:$keyMemberId"
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/SameOriginLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/SameOriginLockRepository.kt
@@ -1,0 +1,17 @@
+package com.adevspoon.domain.common.lock
+
+import org.springframework.stereotype.Component
+import javax.sql.DataSource
+
+@Component
+class SameOriginLockRepository(
+    private val datasource: DataSource
+): DistributedLockRepository {
+    override fun getLock(lockKey: String, timeout: Int, leaseTime: Int): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun releaseLock(lockKey: String): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/SameOriginLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/SameOriginLockRepository.kt
@@ -65,10 +65,7 @@ class SameOriginLockRepository(
         val releaseAllLocksQuery = "SELECT RELEASE_ALL_LOCKS()"
 
         connection.prepareStatement(releaseAllLocksQuery).use { statement ->
-            statement.executeQuery().use { resultSet ->
-                resultSet.next()
-                checkResult(statement, LockType.RELEASE, *keys.map { it.name }.toTypedArray())
-            }
+            checkResult(statement, LockType.RELEASE, *keys.map { it.name }.toTypedArray())
         }
     }
 

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/SameOriginLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/SameOriginLockRepository.kt
@@ -1,17 +1,89 @@
 package com.adevspoon.domain.common.lock
 
-import org.springframework.stereotype.Component
-import javax.sql.DataSource
+import com.adevspoon.domain.common.annotation.LockDataSource
+import com.adevspoon.domain.common.exception.DomainFailToGetLockException
+import com.adevspoon.domain.common.exception.DomainFailToReleaseLockException
+import com.adevspoon.domain.common.lock.interfaces.DistributedLockRepository
+import org.slf4j.LoggerFactory
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 
-@Component
+private const val GET_LOCK = "SELECT GET_LOCK(:key, :timeout)"
+private const val RELEASE_LOCK = "SELECT RELEASE_LOCK(:key)"
+
+
 class SameOriginLockRepository(
-    private val datasource: DataSource
+    @LockDataSource private val jdbcTemplate: NamedParameterJdbcTemplate
 ): DistributedLockRepository {
-    override fun getLock(lockKey: String, timeout: Int, leaseTime: Int): Boolean {
-        TODO("Not yet implemented")
+    private val logger = LoggerFactory.getLogger(this.javaClass)!!
+
+    override fun <R> withLock(key: LockKey, block: () -> R?): R? {
+        try {
+            getLock(key)
+            return block()
+        } finally {
+            releaseLock(key)
+        }
     }
 
-    override fun releaseLock(lockKey: String): Boolean {
-        TODO("Not yet implemented")
+    override fun <R> withAllLock(keys: List<LockKey>, block: () -> R?): R? {
+        try {
+            getAllLock(keys)
+            return block()
+        } finally {
+            releaseAllLock(keys)
+        }
+    }
+
+    override fun getAllLock(keys: List<LockKey>): Boolean {
+        keys.map { getLock(it) }
+        return true
+    }
+
+    override fun releaseAllLock(keys: List<LockKey>): Boolean {
+        keys.map { releaseLock(it) }
+        return true
+    }
+
+    override fun getLock(key: LockKey): Boolean {
+        val params: MutableMap<String, Any?> = mutableMapOf( "key" to key.name, "timeout" to key.timeout)
+        val result = jdbcTemplate.queryForObject(GET_LOCK, params, Int::class.java)
+        return checkResult(result, key.name, LockType.GET)
+    }
+
+    override fun releaseLock(key: LockKey): Boolean {
+        val params: MutableMap<String, Any?> = mutableMapOf( "key" to key.name)
+        val result = jdbcTemplate.queryForObject(RELEASE_LOCK, params, Int::class.java)
+        return checkResult(result, key.name, LockType.RELEASE)
+    }
+
+    private fun checkResult(
+        result: Int?,
+        key: String,
+        type: LockType
+    ): Boolean {
+        when(result) {
+            1 -> logger.info("Lock ${type.name} 성공 : $key")
+            null -> {
+                if (type == LockType.GET) {
+                    logger.error("Lock ${type.name} 실패 : $key")
+                    throw DomainFailToGetLockException(key, "에러 발생")
+                }
+            }
+            else -> {
+                if (type == LockType.GET) {
+                    logger.error("Lock ${type.name} Timeout : $key, result : $result")
+                    throw DomainFailToGetLockException(key, "타임아웃")
+                } else {
+                    logger.error("Lock ${type.name} Not OWNER : $key, result : $result")
+                    throw DomainFailToReleaseLockException(key, "Key의 주인이 아님")
+                }
+            }
+        }
+
+        return true
+    }
+
+    enum class LockType {
+        GET, RELEASE
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/SameOriginLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/SameOriginLockRepository.kt
@@ -2,88 +2,115 @@ package com.adevspoon.domain.common.lock
 
 import com.adevspoon.domain.common.annotation.LockDataSource
 import com.adevspoon.domain.common.exception.DomainFailToGetLockException
+import com.adevspoon.domain.common.exception.DomainFailToLockQueryException
 import com.adevspoon.domain.common.exception.DomainFailToReleaseLockException
 import com.adevspoon.domain.common.lock.interfaces.DistributedLockRepository
 import org.slf4j.LoggerFactory
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import java.sql.Connection
+import java.sql.PreparedStatement
+import javax.sql.DataSource
 
-private const val GET_LOCK = "SELECT GET_LOCK(:key, :timeout)"
-private const val RELEASE_LOCK = "SELECT RELEASE_LOCK(:key)"
 
 
 class SameOriginLockRepository(
-    @LockDataSource private val jdbcTemplate: NamedParameterJdbcTemplate
+    @LockDataSource private val dataSource: DataSource
 ): DistributedLockRepository {
     private val logger = LoggerFactory.getLogger(this.javaClass)!!
 
     override fun <R> withLock(key: LockKey, block: () -> R?): R? {
-        try {
-            getLock(key)
-            return block()
-        } finally {
-            releaseLock(key)
+        dataSource.connection.use {
+            try {
+                getLock(it, key)
+                return block()
+            } finally {
+                releaseLock(it, key)
+            }
         }
     }
 
     override fun <R> withAllLock(keys: List<LockKey>, block: () -> R?): R? {
-        try {
-            getAllLock(keys)
-            return block()
-        } finally {
-            releaseAllLock(keys)
+        if (keys.isEmpty()) return block()
+        else if (keys.size == 1) return withLock(keys[0], block)
+
+        dataSource.connection.use {connection ->
+            try {
+                keys.map { getLock(connection, it) }
+                return block()
+            } finally {
+                releaseAllLock(connection, keys)
+            }
         }
     }
 
-    override fun getAllLock(keys: List<LockKey>): Boolean {
-        keys.map { getLock(it) }
-        return true
+    private fun getLock(connection: Connection, key: LockKey) {
+        val getLockQuery = "SELECT GET_LOCK(?, ?)"
+
+        connection.prepareStatement(getLockQuery).use { statement ->
+            statement.setString(1, key.name)
+            statement.setInt(2, key.timeout)
+            checkResult(statement, LockType.GET, key.name)
+        }
     }
 
-    override fun releaseAllLock(keys: List<LockKey>): Boolean {
-        keys.map { releaseLock(it) }
-        return true
+    private fun releaseLock(connection: Connection, key: LockKey) {
+        val releaseLockQuery = "SELECT RELEASE_LOCK(?)"
+
+        connection.prepareStatement(releaseLockQuery).use { statement ->
+            statement.setString(1, key.name)
+            checkResult(statement, LockType.RELEASE, key.name)
+        }
     }
 
-    override fun getLock(key: LockKey): Boolean {
-        val params: MutableMap<String, Any?> = mutableMapOf( "key" to key.name, "timeout" to key.timeout)
-        val result = jdbcTemplate.queryForObject(GET_LOCK, params, Int::class.java)
-        return checkResult(result, key.name, LockType.GET)
-    }
+    private fun releaseAllLock(connection: Connection, keys: List<LockKey>) {
+        val releaseAllLocksQuery = "SELECT RELEASE_ALL_LOCKS()"
 
-    override fun releaseLock(key: LockKey): Boolean {
-        val params: MutableMap<String, Any?> = mutableMapOf( "key" to key.name)
-        val result = jdbcTemplate.queryForObject(RELEASE_LOCK, params, Int::class.java)
-        return checkResult(result, key.name, LockType.RELEASE)
+        connection.prepareStatement(releaseAllLocksQuery).use { statement ->
+            statement.executeQuery().use { resultSet ->
+                resultSet.next()
+                checkResult(statement, LockType.RELEASE, *keys.map { it.name }.toTypedArray())
+            }
+        }
     }
 
     private fun checkResult(
-        result: Int?,
-        key: String,
-        type: LockType
-    ): Boolean {
-        when(result) {
-            1 -> logger.info("Lock ${type.name} 성공 : $key")
-            null -> {
-                if (type == LockType.GET) {
-                    logger.error("Lock ${type.name} 실패 : $key")
-                    throw DomainFailToGetLockException(key, "에러 발생")
-                }
+        statement: PreparedStatement,
+        type: LockType,
+        vararg key: String,
+    ) {
+        statement.executeQuery().use { resultSet ->
+            if (!resultSet.next()) {
+                logger.error("Lock ${type.name} 실패 : $key")
+                throw DomainFailToLockQueryException()
             }
-            else -> {
-                if (type == LockType.GET) {
-                    logger.error("Lock ${type.name} Timeout : $key, result : $result")
-                    throw DomainFailToGetLockException(key, "타임아웃")
-                } else {
-                    logger.error("Lock ${type.name} Not OWNER : $key, result : $result")
-                    throw DomainFailToReleaseLockException(key, "Key의 주인이 아님")
+
+            val result = resultSet.getInt(1)
+            when(type) {
+                LockType.GET -> {
+                    if (result == 0) {
+                        logger.error("Lock ${type.name} 실패 : $key")
+                        throw DomainFailToGetLockException(key[0], "에러 발생")
+                    }
+                    logger.info("Lock ${type.name} 성공 : $key")
+                }
+                LockType.RELEASE -> {
+                    if (result == 0) {
+                        logger.error("Lock ${type.name} 실패 : $key")
+                        throw DomainFailToReleaseLockException(key[0], "에러 발생")
+                    }
+                    logger.info("Lock ${type.name} 성공 : $key")
+                }
+                LockType.RELEASE_ALL -> {
+                    if (result == 0) {
+                        logger.error("Lock ${type.name} 실패 : $key")
+                        throw DomainFailToReleaseLockException(key.joinToString(", "), "에러 발생")
+                    }
+                    logger.info("Lock ${type.name} 성공 : $key")
                 }
             }
         }
-
-        return true
     }
 
     enum class LockType {
-        GET, RELEASE
+        GET, RELEASE, RELEASE_ALL
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/DistributedLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/DistributedLockRepository.kt
@@ -1,8 +1,3 @@
 package com.adevspoon.domain.common.lock.interfaces
 
-import com.adevspoon.domain.common.lock.LockKey
-
-interface DistributedLockRepository: ListableLockRepository {
-    fun <R> withLock(key: LockKey, block: () -> R?): R?
-    fun <R> withAllLock(keys: List<LockKey>, block: () -> R?): R?
-}
+interface DistributedLockRepository: ListableLockRepository

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/DistributedLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/DistributedLockRepository.kt
@@ -1,0 +1,8 @@
+package com.adevspoon.domain.common.lock.interfaces
+
+import com.adevspoon.domain.common.lock.LockKey
+
+interface DistributedLockRepository: ListableLockRepository {
+    fun <R> withLock(key: LockKey, block: () -> R?): R?
+    fun <R> withAllLock(keys: List<LockKey>, block: () -> R?): R?
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/ListableLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/ListableLockRepository.kt
@@ -1,0 +1,8 @@
+package com.adevspoon.domain.common.lock.interfaces
+
+import com.adevspoon.domain.common.lock.LockKey
+
+interface ListableLockRepository: LockRepository {
+    fun getAllLock(keys: List<LockKey>): Boolean
+    fun releaseAllLock(keys: List<LockKey>): Boolean
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/ListableLockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/ListableLockRepository.kt
@@ -3,6 +3,5 @@ package com.adevspoon.domain.common.lock.interfaces
 import com.adevspoon.domain.common.lock.LockKey
 
 interface ListableLockRepository: LockRepository {
-    fun getAllLock(keys: List<LockKey>): Boolean
-    fun releaseAllLock(keys: List<LockKey>): Boolean
+    fun <R> withAllLock(keys: List<LockKey>, block: () -> R?): R?
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/LockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/LockRepository.kt
@@ -3,6 +3,5 @@ package com.adevspoon.domain.common.lock.interfaces
 import com.adevspoon.domain.common.lock.LockKey
 
 interface LockRepository {
-    fun getLock(key: LockKey): Boolean
-    fun releaseLock(key: LockKey): Boolean
+    fun <R> withLock(key: LockKey, block: () -> R?): R?
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/LockRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/lock/interfaces/LockRepository.kt
@@ -1,0 +1,8 @@
+package com.adevspoon.domain.common.lock.interfaces
+
+import com.adevspoon.domain.common.lock.LockKey
+
+interface LockRepository {
+    fun getLock(key: LockKey): Boolean
+    fun releaseLock(key: LockKey): Boolean
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/JpaConfig.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/JpaConfig.kt
@@ -1,13 +1,36 @@
 package com.adevspoon.domain.config
 
+import com.zaxxer.hikari.HikariDataSource
 import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import javax.sql.DataSource
 
 
 @Configuration
 @EnableJpaAuditing
 @EntityScan(basePackages = ["com.adevspoon.domain"])
 @EnableJpaRepositories(basePackages = ["com.adevspoon.domain"])
-class JpaConfig
+class JpaConfig {
+
+    @Bean
+    @Primary
+    @ConfigurationProperties("spring.datasource")
+    fun mainDataSourceProperties(): DataSourceProperties {
+        return DataSourceProperties()
+    }
+
+    @Bean
+    @Primary
+    fun mainDataSource(): DataSource {
+        return mainDataSourceProperties()
+            .initializeDataSourceBuilder()
+            .type(HikariDataSource::class.java)
+            .build()
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/LockSourceConfig.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/LockSourceConfig.kt
@@ -9,7 +9,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import javax.sql.DataSource
 
 
@@ -24,18 +23,13 @@ class LockSourceConfig {
     }
 
     @Bean
-    fun lockSource(): DataSource {
+    @LockDataSource
+    fun lockDataSource(): DataSource {
         return HikariDataSource(lockHikariConfig())
     }
 
     @Bean
-    @LockDataSource
-    fun lockJdbcTemplate(): NamedParameterJdbcTemplate {
-        return NamedParameterJdbcTemplate(lockSource())
-    }
-
-    @Bean
     fun lockRepository(): DistributedLockRepository {
-        return SameOriginLockRepository(lockJdbcTemplate())
+        return SameOriginLockRepository(lockDataSource())
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/LockSourceConfig.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/LockSourceConfig.kt
@@ -1,0 +1,41 @@
+package com.adevspoon.domain.config
+
+import com.adevspoon.domain.common.annotation.LockDataSource
+import com.adevspoon.domain.common.lock.SameOriginLockRepository
+import com.adevspoon.domain.common.lock.interfaces.DistributedLockRepository
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import javax.sql.DataSource
+
+
+@Configuration
+@ConditionalOnProperty(prefix = "spring.lock-datasource", name = ["jdbc-url"])
+class LockSourceConfig {
+
+    @Bean
+    @ConfigurationProperties("spring.lock-datasource")
+    fun lockHikariConfig(): HikariConfig {
+        return HikariConfig()
+    }
+
+    @Bean
+    fun lockSource(): DataSource {
+        return HikariDataSource(lockHikariConfig())
+    }
+
+    @Bean
+    @LockDataSource
+    fun lockJdbcTemplate(): NamedParameterJdbcTemplate {
+        return NamedParameterJdbcTemplate(lockSource())
+    }
+
+    @Bean
+    fun lockRepository(): DistributedLockRepository {
+        return SameOriginLockRepository(lockJdbcTemplate())
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
@@ -64,7 +64,6 @@ class MemberDomainService(
     @Transactional
     fun updateMemberProfile(updateInfo: MemberUpdateRequireDto): MemberProfile {
         val user = getUserEntity(updateInfo.memberId)
-        logger.warn("유저정보 확인 : ${user.oAuth}")
         val userBadgeList = userBadgeAchieveRepository.findUserBadgeList(updateInfo.memberId)
         var userRepresentativeBadge = userBadgeList.firstOrNull {
             it.id?.equals(user.representativeBadge) ?: false

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionCategoryEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionCategoryEntity.kt
@@ -14,8 +14,8 @@ class QuestionCategoryEntity(
     var id: Long = 0,
 
     @Size(max = 255)
-    @Column(name = "category")
-    val category: String? = null,
+    @Column(name = "category", nullable = false)
+    val category: String,
 
     @NotNull
     @Column(name = "topic", columnDefinition="ENUM('cs','language','tech')", nullable = false)
@@ -31,21 +31,21 @@ class QuestionCategoryEntity(
     @Column(name = "description", nullable = false)
     var description: String? = null,
 
+    @Column(name = "iconUrl")
+    var iconUrl: String,
+
     @Size(max = 6)
     @NotNull
     @Column(name = "backgroundColor", nullable = false, length = 6)
-    var backgroundColor: String? = null,
-
-    @Column(name = "iconUrl")
-    var iconUrl: String? = null,
+    var backgroundColor: String,
 
     @Size(max = 6)
     @NotNull
     @Column(name = "accentColor", nullable = false, length = 6)
-    var accentColor: String? = null,
+    var accentColor: String,
 
     @Size(max = 6)
     @NotNull
     @Column(name = "iconColor", nullable = false, length = 6)
-    var iconColor: String? = null
+    var iconColor: String
 )

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionEntity.kt
@@ -30,8 +30,8 @@ class QuestionEntity(
     var notionId: String? = null,
 
     // QuestionCategory
-    @Column(name = "category_id")
-    val categoryId: Long? = null,
+    @Column(name = "category_id", nullable = false)
+    val categoryId: Long,
 
     @Column(name = "sequence")
     var sequence: Int? = null

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionOpenEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionOpenEntity.kt
@@ -22,17 +22,17 @@ class QuestionOpenEntity(
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "question_id", nullable = false)
-    val question: QuestionEntity? = null,
+    val question: QuestionEntity,
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id", nullable = false)
-    val user: UserEntity? = null,
+    val user: UserEntity,
 
     @NotNull
     @Column(name = "open_date", nullable = false)
-    var openDate: LocalDateTime? = null,
+    var openDate: LocalDateTime,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @OnDelete(action = OnDeleteAction.SET_NULL)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/request/GetTodayQuestion.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/request/GetTodayQuestion.kt
@@ -1,0 +1,11 @@
+package com.adevspoon.domain.techQuestion.dto.request
+
+import com.adevspoon.domain.common.lock.IssueQuestionLockKey
+import java.time.LocalDate
+
+data class GetTodayQuestion(
+    val memberId: Long,
+    val today: LocalDate
+): IssueQuestionLockKey {
+    override val keyMemberId: Long = memberId
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/QuestionInfo.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/QuestionInfo.kt
@@ -1,0 +1,38 @@
+package com.adevspoon.domain.techQuestion.dto.response
+
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class QuestionInfo(
+    val questionId: Long,
+    val question: String,
+    val difficulty: Int = 0,
+    val studyLink: String,
+    val categoryName: String,
+
+    val tag: List<String>? = null,
+    val openDate: LocalDate,
+    val answerId: Long? = null,
+    val isLast: Boolean = false,
+
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(open: QuestionOpenEntity, categoryName: String, isLast: Boolean = false) =
+            QuestionInfo(
+                questionId = open.question.id,
+                question = open.question.question ?: "",
+                difficulty = open.question.difficulty ?: 0,
+                studyLink = open.question.studyLink ?: "",
+                categoryName = categoryName,
+                tag = arrayListOf(),
+                openDate = open.openDate.toLocalDate(),
+                answerId = open.answer?.id,
+                isLast = isLast,
+                createdAt = open.createdAt ?: LocalDateTime.now(),
+                updatedAt = open.updatedAt ?: LocalDateTime.now(),
+            )
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
@@ -4,9 +4,15 @@ package com.adevspoon.domain.techQuestion.exception
 import com.adevspoon.common.exception.AdevspoonErrorCode
 import com.adevspoon.common.exception.DomainType
 
+private val domain = DomainType.TECH_QUESTION
+
 enum class QuestionDomainErrorCode(
     override val error: DomainType.Error,
     override val message: String,
 ): AdevspoonErrorCode {
-    QUESTION_CATEGORY_NOT_FOUND(DomainType.TECH_QUESTION code 404 no 0, "등록되지 않은 카테고리 등록");
+    QUESTION_NOT_OPENED(domain code 400 no 1, "발급받지 않은 Question 입니다"),
+    QUESTION_EXHAUSTED(domain code 400 no 2, "발급 가능한 Question이 없습니다"),
+
+    QUESTION_NOT_FOUND(domain code 404 no 0, "없는 Question ID로 조회 시도"),
+    QUESTION_CATEGORY_NOT_FOUND(domain code 404 no 1, "없는 카테고리 ID로 등록 시도"),
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
@@ -2,4 +2,8 @@ package com.adevspoon.domain.techQuestion.exception
 
 import com.adevspoon.common.exception.AdevspoonException
 
+class QuestionNotOpenedException : AdevspoonException(QuestionDomainErrorCode.QUESTION_NOT_OPENED)
+class QuestionExhaustedException : AdevspoonException(QuestionDomainErrorCode.QUESTION_EXHAUSTED)
+
+class QuestionNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_NOT_FOUND)
 class QuestionCategoryNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_CATEGORY_NOT_FOUND)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionCategoryRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionCategoryRepository.kt
@@ -7,4 +7,7 @@ import org.springframework.data.jpa.repository.Query
 interface QuestionCategoryRepository: JpaRepository<QuestionCategoryEntity, Long> {
     @Query("SELECT qc from QuestionCategoryEntity qc where qc.id in :ids")
     fun findQuestionCategoryByIds(ids: List<Long>): List<QuestionCategoryEntity>
+
+    @Query("SELECT qc.id from QuestionCategoryEntity qc")
+    fun findAllIds(): List<Long>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
@@ -1,0 +1,25 @@
+package com.adevspoon.domain.techQuestion.repository
+
+import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface QuestionOpenRepository: JpaRepository<QuestionOpenEntity, Long> {
+    @Query("SELECT qo " +
+            "FROM QuestionOpenEntity qo " +
+                "join fetch qo.question " +
+                "join fetch qo.answer " +
+            "WHERE qo.user.id = :memberId " +
+            "ORDER BY qo.createdAt DESC " +
+            "LIMIT 1")
+    fun findLatest(memberId: Long): QuestionOpenEntity?
+
+    @Query("SELECT qo " +
+            "FROM QuestionOpenEntity qo " +
+                "join fetch qo.question " +
+                "join fetch qo.answer " +
+            "WHERE qo.question = :question AND qo.user = :user ")
+    fun findByQuestionAndUser(question: QuestionEntity, user: UserEntity): QuestionOpenEntity?
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
@@ -9,17 +9,20 @@ import org.springframework.data.jpa.repository.Query
 interface QuestionOpenRepository: JpaRepository<QuestionOpenEntity, Long> {
     @Query("SELECT qo " +
             "FROM QuestionOpenEntity qo " +
-                "join fetch qo.question " +
-                "join fetch qo.answer " +
-            "WHERE qo.user.id = :memberId " +
+                "LEFT JOIN FETCH qo.question " +
+                "LEFT JOIN FETCH qo.answer " +
+            "WHERE qo.user = :user " +
             "ORDER BY qo.createdAt DESC " +
             "LIMIT 1")
-    fun findLatest(memberId: Long): QuestionOpenEntity?
+    fun findLatest(user: UserEntity): QuestionOpenEntity?
 
     @Query("SELECT qo " +
             "FROM QuestionOpenEntity qo " +
-                "join fetch qo.question " +
-                "join fetch qo.answer " +
+                "LEFT JOIN FETCH qo.question " +
+                "LEFT JOIN FETCH qo.answer " +
             "WHERE qo.question = :question AND qo.user = :user ")
     fun findByQuestionAndUser(question: QuestionEntity, user: UserEntity): QuestionOpenEntity?
+
+    @Query("SELECT qo.question.id FROM QuestionOpenEntity qo WHERE qo.user = :user")
+    fun findAllIssuedQuestionIds(user: UserEntity): Set<Long>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionRepository.kt
@@ -2,8 +2,9 @@ package com.adevspoon.domain.techQuestion.repository
 
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface QuestionRepository: JpaRepository<QuestionEntity, Long> {
-
-
+    @Query("SELECT q.id from QuestionEntity q where q.categoryId in :categoryIds")
+    fun findAllQuestionIds(categoryIds: List<Long>): Set<Long>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionRepository.kt
@@ -1,0 +1,9 @@
+package com.adevspoon.domain.techQuestion.repository
+
+import com.adevspoon.domain.techQuestion.domain.QuestionEntity
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface QuestionRepository: JpaRepository<QuestionEntity, Long> {
+
+
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/UserCustomizedQuestionCategoryRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/UserCustomizedQuestionCategoryRepository.kt
@@ -1,5 +1,6 @@
 package com.adevspoon.domain.techQuestion.repository
 
+import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.techQuestion.domain.UserCustomizedQuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.UserCustomizedQuestionCategoryId
 import org.springframework.data.jpa.repository.JpaRepository
@@ -9,6 +10,9 @@ import org.springframework.data.jpa.repository.Query
 
 interface UserCustomizedQuestionCategoryRepository: JpaRepository<UserCustomizedQuestionCategoryEntity, UserCustomizedQuestionCategoryId> {
     @Modifying(clearAutomatically = true)
-    @Query("delete from UserCustomizedQuestionCategoryEntity qc where qc.id.user.id = :userId")
-    fun deleteAllByUserId(userId: Long)
+    @Query("delete from UserCustomizedQuestionCategoryEntity qc where qc.id.user = :user")
+    fun deleteAllByUser(user: UserEntity)
+
+    @Query("select qc.id.category.id from UserCustomizedQuestionCategoryEntity qc where qc.id.user = :user")
+    fun findAllSelectedCategoryIds(user: UserEntity): List<Long>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
@@ -39,7 +39,6 @@ class QuestionDomainService(
         return makeQuestionInfo(issuedQuestion)
     }
 
-    // TODO: Distributed Lock 필요 (트랜잭션 전에 GetLock, 트랜잭션 후에 ReleaseLock)
     @Transactional
     @DistributedLock(keyClass = [GetTodayQuestion::class])
     fun getOrCreateTodayQuestion(request: GetTodayQuestion): QuestionInfo {

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
@@ -2,19 +2,54 @@ package com.adevspoon.domain.techQuestion.service
 
 import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.member.exception.MemberNotFoundException
+import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
 import com.adevspoon.domain.techQuestion.domain.UserCustomizedQuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.UserCustomizedQuestionCategoryId
+import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
 import com.adevspoon.domain.techQuestion.exception.QuestionCategoryNotFoundException
-import com.adevspoon.domain.techQuestion.exception.QuestionDomainErrorCode
+import com.adevspoon.domain.techQuestion.exception.QuestionNotFoundException
+import com.adevspoon.domain.techQuestion.exception.QuestionNotOpenedException
 import com.adevspoon.domain.techQuestion.repository.QuestionCategoryRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionRepository
 import com.adevspoon.domain.techQuestion.repository.UserCustomizedQuestionCategoryRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 
 @DomainService
 class QuestionDomainService(
     private val questionCategoryRepository: QuestionCategoryRepository,
-    private val userCustomizedQuestionCategoryRepository: UserCustomizedQuestionCategoryRepository
+    private val questionRepository: QuestionRepository,
+    private val questionOpenRepository: QuestionOpenRepository,
+    private val userRepository: UserRepository,
+    private val userCustomizedQuestionCategoryRepository: UserCustomizedQuestionCategoryRepository,
+    private val questionOpenDomainService: QuestionOpenDomainService,
 ) {
+    private val logger = LoggerFactory.getLogger(this.javaClass)!!
+    @Transactional(readOnly = true)
+    fun getQuestion(memberId: Long, questionId: Long): QuestionInfo {
+        val user = userRepository.findByIdOrNull(memberId) ?: throw throw MemberNotFoundException()
+        val question = questionRepository.findByIdOrNull(questionId) ?: throw throw QuestionNotFoundException()
+        val issuedQuestion = questionOpenRepository.findByQuestionAndUser(question, user) ?: throw throw QuestionNotOpenedException()
+
+        return makeQuestionInfo(issuedQuestion)
+    }
+
+    // TODO: Distributed Lock 필요 (트랜잭션 전에 GetLock, 트랜잭션 후에 ReleaseLock)
+    @Transactional
+    fun getOrCreateTodayQuestion(memberId: Long, today: LocalDate): QuestionInfo {
+        val user = userRepository.findByIdOrNull(memberId) ?: throw throw MemberNotFoundException()
+        val latestIssuedQuestion = questionOpenRepository.findLatest(user)
+
+        val isTodayQuestion = (latestIssuedQuestion?.openDate?.toLocalDate()?.compareTo(today) ?: -1) == 0
+
+        return if(isTodayQuestion) makeQuestionInfo(latestIssuedQuestion!!)
+        else questionOpenDomainService.issueQuestion(memberId, today)
+    }
 
     @Transactional
     fun updateQuestionCategory(user: UserEntity, categoryIds: List<Long>) {
@@ -26,8 +61,14 @@ class QuestionDomainService(
             ?.map { UserCustomizedQuestionCategoryEntity(UserCustomizedQuestionCategoryId(it, user)) }
             ?: throw QuestionCategoryNotFoundException()
 
-        userCustomizedQuestionCategoryRepository.deleteAllByUserId(user.id)
-        // TODO: saveAll 한 번에 처리 필요(select N번, insert N번 나감)
+        userCustomizedQuestionCategoryRepository.deleteAllByUser(user)
+        // FIXME: saveAll 한 번에 처리 필요(select N번, insert N번 나감)
         userCustomizedQuestionCategoryRepository.saveAll(newCustomizedQuestionCategories)
+    }
+
+    private fun makeQuestionInfo(questionOpen: QuestionOpenEntity): QuestionInfo {
+        val category = questionCategoryRepository.findByIdOrNull(questionOpen.question.categoryId)
+            ?: throw QuestionCategoryNotFoundException()
+        return QuestionInfo.from(questionOpen, category.category)
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
@@ -1,0 +1,61 @@
+package com.adevspoon.domain.techQuestion.service
+
+import com.adevspoon.domain.common.annotation.DomainService
+import com.adevspoon.domain.member.exception.MemberNotFoundException
+import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
+import com.adevspoon.domain.techQuestion.exception.QuestionCategoryNotFoundException
+import com.adevspoon.domain.techQuestion.exception.QuestionExhaustedException
+import com.adevspoon.domain.techQuestion.exception.QuestionNotFoundException
+import com.adevspoon.domain.techQuestion.repository.QuestionCategoryRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionRepository
+import com.adevspoon.domain.techQuestion.repository.UserCustomizedQuestionCategoryRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@DomainService
+class QuestionOpenDomainService(
+    private val questionCategoryRepository: QuestionCategoryRepository,
+    private val questionOpenRepository: QuestionOpenRepository,
+    private val questionRepository: QuestionRepository,
+    private val userRepository: UserRepository,
+    private val userCustomizedQuestionCategoryRepository: UserCustomizedQuestionCategoryRepository,
+) {
+    private val logger = LoggerFactory.getLogger(this.javaClass)!!
+
+    // TODO: 발급받은 Question Count 증가 필요 (@Transactional 내에서 실행, commit 이후에 Event로 처리 되어야함)
+    // 반드시 이전 트랜잭션에서 호출되어야 함(이전 트랜잭션에서 락 걸기 때문에)
+    @Transactional(propagation = Propagation.MANDATORY)
+    fun issueQuestion(memberId: Long, today: LocalDate): QuestionInfo {
+        // 정책 - 1일 1회 Random 발급
+        logger.info("질문발급 : memberId($memberId), today($today)")
+        val user = userRepository.findByIdOrNull(memberId) ?: throw MemberNotFoundException()
+        val selectedCategoryIds = userCustomizedQuestionCategoryRepository.findAllSelectedCategoryIds(user)
+            .takeIf { it.isNotEmpty() }
+            ?: questionCategoryRepository.findAllIds()
+
+        val alreadyIssuedQuestionIds = questionOpenRepository.findAllIssuedQuestionIds(user)
+        val candidateIssuableQuestionIds =
+            (questionRepository.findAllQuestionIds(selectedCategoryIds) - alreadyIssuedQuestionIds)
+                .takeIf { it.isNotEmpty() }
+                ?: throw QuestionExhaustedException()
+
+        val issuedQuestionId = candidateIssuableQuestionIds.random()
+        val issuedQuestion = questionRepository.findByIdOrNull(issuedQuestionId) ?: throw QuestionNotFoundException()
+        val questionOpen = QuestionOpenEntity(user = user, question = issuedQuestion, openDate = today.atStartOfDay())
+        questionOpenRepository.save(questionOpen)
+
+        return makeQuestionInfo(questionOpen, candidateIssuableQuestionIds.size == 1)
+    }
+
+    private fun makeQuestionInfo(questionOpen: QuestionOpenEntity, isLast: Boolean = false): QuestionInfo {
+        val category = questionCategoryRepository.findByIdOrNull(questionOpen.question.categoryId)
+            ?: throw QuestionCategoryNotFoundException()
+        return QuestionInfo.from(questionOpen, category.category, isLast)
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
@@ -28,7 +28,6 @@ class QuestionOpenDomainService(
 ) {
     private val logger = LoggerFactory.getLogger(this.javaClass)!!
 
-    // TODO: 발급받은 Question Count 증가 필요 (@Transactional 내에서 실행, commit 이후에 Event로 처리 되어야함)
     @Transactional(propagation = Propagation.MANDATORY)
     fun issueQuestion(memberId: Long, today: LocalDate): QuestionInfo {
         // 정책 - 1일 1회 Random 발급
@@ -48,6 +47,8 @@ class QuestionOpenDomainService(
         val question = questionRepository.findByIdOrNull(issuedQuestionId) ?: throw QuestionNotFoundException()
         val issuedQuestion = QuestionOpenEntity(user = user, question = question, openDate = today.atStartOfDay())
         questionOpenRepository.save(issuedQuestion)
+
+        user.apply { questionCnt += 1 }
 
         return makeQuestionInfo(issuedQuestion, candidateIssuableQuestionIds.size == 1)
     }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
@@ -46,11 +46,11 @@ class QuestionOpenDomainService(
                 ?: throw QuestionExhaustedException()
 
         val issuedQuestionId = candidateIssuableQuestionIds.random()
-        val issuedQuestion = questionRepository.findByIdOrNull(issuedQuestionId) ?: throw QuestionNotFoundException()
-        val questionOpen = QuestionOpenEntity(user = user, question = issuedQuestion, openDate = today.atStartOfDay())
-        questionOpenRepository.save(questionOpen)
+        val question = questionRepository.findByIdOrNull(issuedQuestionId) ?: throw QuestionNotFoundException()
+        val issuedQuestion = QuestionOpenEntity(user = user, question = question, openDate = today.atStartOfDay())
+        questionOpenRepository.save(issuedQuestion)
 
-        return makeQuestionInfo(questionOpen, candidateIssuableQuestionIds.size == 1)
+        return makeQuestionInfo(issuedQuestion, candidateIssuableQuestionIds.size == 1)
     }
 
     private fun makeQuestionInfo(questionOpen: QuestionOpenEntity, isLast: Boolean = false): QuestionInfo {

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
@@ -29,7 +29,6 @@ class QuestionOpenDomainService(
     private val logger = LoggerFactory.getLogger(this.javaClass)!!
 
     // TODO: 발급받은 Question Count 증가 필요 (@Transactional 내에서 실행, commit 이후에 Event로 처리 되어야함)
-    // 반드시 이전 트랜잭션에서 호출되어야 함(이전 트랜잭션에서 락 걸기 때문에)
     @Transactional(propagation = Propagation.MANDATORY)
     fun issueQuestion(memberId: Long, today: LocalDate): QuestionInfo {
         // 정책 - 1일 1회 Random 발급

--- a/adevspoon-domain/src/main/resources/application-domain-test.yml
+++ b/adevspoon-domain/src/main/resources/application-domain-test.yml
@@ -2,6 +2,10 @@ spring:
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:mysql:8:///
+  lock-datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    jdbc-url: jdbc:tc:mysql:8:///
+    pool-name: lock-pool
   jpa:
     hibernate:
       ddl-auto: update

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/MemberFixture.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/MemberFixture.kt
@@ -1,0 +1,15 @@
+package com.adevspoon.domain.fixture
+
+import com.adevspoon.domain.member.domain.UserEntity
+
+class MemberFixture {
+    companion object {
+        fun createMember(
+            id: Long? = null,
+            nickname: String = "nickname",
+        ) = UserEntity(
+            id = id ?: 1,
+            nickname = nickname,
+        )
+    }
+}

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/MemberFixture.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/MemberFixture.kt
@@ -5,10 +5,10 @@ import com.adevspoon.domain.member.domain.UserEntity
 class MemberFixture {
     companion object {
         fun createMember(
-            id: Long? = null,
+            id: Long = 1,
             nickname: String = "nickname",
         ) = UserEntity(
-            id = id ?: 1,
+            id = id,
             nickname = nickname,
         )
     }

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
@@ -1,0 +1,62 @@
+package com.adevspoon.domain.fixture
+
+import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.domain.enums.QuestionCategoryTopic
+import java.time.LocalDateTime
+
+class QuestionFixture {
+    companion object {
+        fun createQuestion(
+            id: Long? = null,
+            question: String = "question",
+            difficulty: Int = 0,
+            studyLink: String = "studyLink",
+            notionId: String = "notionId",
+            categoryId: Long = 0
+        ) = QuestionEntity(
+            id = id ?: 1,
+            question = question,
+            difficulty = difficulty,
+            studyLink = studyLink,
+            notionId = notionId,
+            categoryId = categoryId,
+        )
+
+        fun createQuestionOpen(
+            id: Long? = null,
+            question: QuestionEntity = createQuestion(),
+            openDate: LocalDateTime = LocalDateTime.now(),
+            user: UserEntity = MemberFixture.createMember()
+        ) = QuestionOpenEntity(
+            id = id ?: 1,
+            openDate = openDate,
+            question = question,
+            user = user,
+        )
+
+        fun createQuestionCategory(
+            id: Long? = null,
+            category: String = "category",
+            topic: QuestionCategoryTopic = QuestionCategoryTopic.CS,
+            subtitle: String = "subtitle",
+            description: String = "description",
+            iconUrl: String = "iconUrl",
+            backgroundColor: String = "backgroundColor",
+            accentColor: String = "accentColor",
+            iconColor: String = "iconColor",
+        ) = QuestionCategoryEntity(
+            id = id ?: 1,
+            category = category,
+            topic = topic,
+            subtitle = subtitle,
+            description = description,
+            iconUrl = iconUrl,
+            backgroundColor = backgroundColor,
+            accentColor = accentColor,
+            iconColor = iconColor,
+        )
+    }
+}

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
@@ -5,6 +5,8 @@ import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
 import com.adevspoon.domain.techQuestion.domain.enums.QuestionCategoryTopic
+import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class QuestionFixture {
@@ -57,6 +59,32 @@ class QuestionFixture {
             backgroundColor = backgroundColor,
             accentColor = accentColor,
             iconColor = iconColor,
+        )
+
+        fun createQuestionInfo(
+            questionId: Long = 1,
+            question: String = "question",
+            difficulty: Int = 0,
+            studyLink: String = "studyLink",
+            categoryName: String = "category",
+            tag: List<String> = listOf(),
+            openDate: LocalDate = LocalDate.now(),
+            answerId: Long? = null,
+            isLast: Boolean = false,
+            createdAt: LocalDateTime = LocalDateTime.now(),
+            updatedAt: LocalDateTime = LocalDateTime.now(),
+        ) = QuestionInfo(
+            questionId = questionId,
+            question = question,
+            difficulty = difficulty,
+            studyLink = studyLink,
+            categoryName = categoryName,
+            tag = tag,
+            openDate = openDate,
+            answerId = answerId,
+            isLast = isLast,
+            createdAt = createdAt,
+            updatedAt = updatedAt,
         )
     }
 }

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
@@ -17,7 +17,7 @@ class QuestionFixture {
             difficulty: Int = 0,
             studyLink: String = "studyLink",
             notionId: String = "notionId",
-            categoryId: Long = 0
+            categoryId: Long = 1
         ) = QuestionEntity(
             id = id ?: 1,
             question = question,
@@ -40,17 +40,17 @@ class QuestionFixture {
         )
 
         fun createQuestionCategory(
-            id: Long? = null,
+            id: Long = 1,
             category: String = "category",
             topic: QuestionCategoryTopic = QuestionCategoryTopic.CS,
             subtitle: String = "subtitle",
             description: String = "description",
             iconUrl: String = "iconUrl",
-            backgroundColor: String = "backgroundColor",
-            accentColor: String = "accentColor",
-            iconColor: String = "iconColor",
+            backgroundColor: String = "colors",
+            accentColor: String = "colors",
+            iconColor: String = "colors",
         ) = QuestionCategoryEntity(
-            id = id ?: 1,
+            id = id,
             category = category,
             topic = topic,
             subtitle = subtitle,

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/member/service/MemberDomainServiceIntegrationTest.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/member/service/MemberDomainServiceIntegrationTest.kt
@@ -7,9 +7,8 @@ import com.adevspoon.domain.member.domain.UserBadgeAcheiveId
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.dto.request.MemberUpdateRequireDto
 import com.adevspoon.domain.member.repository.BadgeRepository
-import com.adevspoon.domain.member.repository.UserBadgeAcheiveRepository
+import com.adevspoon.domain.member.repository.UserBadgeAchieveRepository
 import com.adevspoon.domain.member.repository.UserRepository
-import com.adevspoon.domain.techQuestion.service.QuestionDomainService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -19,13 +18,10 @@ import org.springframework.beans.factory.annotation.Autowired
 
 @DomainIntegrationTest
 class MemberDomainServiceIntegrationTest {
-
     @Autowired lateinit var memberDomainService: MemberDomainService
     @Autowired lateinit var userRepository: UserRepository
     @Autowired lateinit var badgeRepository: BadgeRepository
-    @Autowired lateinit var userBadgeAcheiveRepository: UserBadgeAcheiveRepository
-    @Autowired lateinit var questionDomainService: QuestionDomainService
-
+    @Autowired lateinit var userBadgeAchieveRepository: UserBadgeAchieveRepository
 
     @Nested
     inner class UpdateMemberProfile {
@@ -42,11 +38,11 @@ class MemberDomainServiceIntegrationTest {
             val userBadge = UserBadgeAcheiveEntity(UserBadgeAcheiveId(user, badge))
             userRepository.save(user)
             badgeRepository.save(badge)
-            userBadgeAcheiveRepository.save(userBadge)
+            userBadgeAchieveRepository.save(userBadge)
         }
 
         @Test
-        fun `SUCCESS - 플레인 데이터 업데이트 성공`() {
+        fun `SUCCESS - 유저 플레인 데이터 업데이트 성공`() {
             // given
             val updateInfo = MemberUpdateRequireDto(
                 memberId = 1,

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceIntegrationTest.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceIntegrationTest.kt
@@ -55,7 +55,6 @@ class QuestionDomainServiceIntegrationTest {
                 val questionInfo =
                     questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(1, LocalDate.now()))
                 questionInfoList.add(questionInfo)
-                // 동시성으로 create 메서드 호출
                 latch.countDown()
             }
         }

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceIntegrationTest.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceIntegrationTest.kt
@@ -1,0 +1,73 @@
+package com.adevspoon.domain.techQuestion.service
+
+import com.adevspoon.domain.annotation.DomainIntegrationTest
+import com.adevspoon.domain.fixture.MemberFixture
+import com.adevspoon.domain.fixture.QuestionFixture
+import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.dto.request.GetTodayQuestion
+import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
+import com.adevspoon.domain.techQuestion.repository.QuestionCategoryRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionRepository
+import com.adevspoon.domain.techQuestion.repository.UserCustomizedQuestionCategoryRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+
+
+@DomainIntegrationTest
+class QuestionDomainServiceIntegrationTest {
+    @Autowired private lateinit var questionDomainService: QuestionDomainService
+
+    @Autowired private lateinit var questionCategoryRepository: QuestionCategoryRepository
+    @Autowired private lateinit var questionRepository: QuestionRepository
+    @Autowired private lateinit var questionOpenRepository: QuestionOpenRepository
+    @Autowired private lateinit var userRepository: UserRepository
+    @Autowired private lateinit var userCustomizedQuestionCategoryRepository: UserCustomizedQuestionCategoryRepository
+    @Autowired private lateinit var questionOpenDomainService: QuestionOpenDomainService
+
+    @BeforeEach
+    fun setup() {
+        val user = MemberFixture.createMember(1)
+        val question1 = QuestionFixture.createQuestion(1)
+        val question2 = QuestionFixture.createQuestion(2)
+        val questionCategory = QuestionFixture.createQuestionCategory(1)
+
+        userRepository.save(user)
+        questionRepository.save(question1)
+        questionRepository.save(question2)
+        questionCategoryRepository.save(questionCategory)
+    }
+
+    @Test
+    fun `getOrCreateTodayQuestion - 문제 발급 동시성 테스트`() {
+        val numThreads = 3
+        val latch = CountDownLatch(numThreads)
+        val executor = Executors.newFixedThreadPool(numThreads)
+        val questionInfoList = mutableListOf<QuestionInfo>()
+
+        for (i in 0 until numThreads) {
+            executor.execute {
+                val questionInfo =
+                    questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(1, LocalDate.now()))
+                questionInfoList.add(questionInfo)
+                // 동시성으로 create 메서드 호출
+                latch.countDown()
+            }
+        }
+
+        latch.await()
+        executor.shutdown()
+        val questionId = questionInfoList[0].questionId
+
+        assertAll({
+            questionInfoList.forEach {
+                assertEquals(it.questionId, questionId)
+            }
+        })
+    }
+}

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceUnitTest.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceUnitTest.kt
@@ -1,0 +1,146 @@
+package com.adevspoon.domain.techQuestion.service
+
+import com.adevspoon.domain.fixture.MemberFixture
+import com.adevspoon.domain.fixture.QuestionFixture
+import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.domain.QuestionEntity
+import com.adevspoon.domain.techQuestion.dto.request.GetTodayQuestion
+import com.adevspoon.domain.techQuestion.exception.QuestionNotOpenedException
+import com.adevspoon.domain.techQuestion.repository.QuestionCategoryRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionRepository
+import com.adevspoon.domain.techQuestion.repository.UserCustomizedQuestionCategoryRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class QuestionDomainServiceUnitTest {
+    private val questionCategoryRepository = mockk<QuestionCategoryRepository>()
+    private val questionRepository = mockk<QuestionRepository>()
+    private val questionOpenRepository = mockk<QuestionOpenRepository>()
+    private val userRepository = mockk<UserRepository>()
+    private val userCustomizedQuestionCategoryRepository = mockk<UserCustomizedQuestionCategoryRepository>()
+    private val questionOpenDomainService = mockk<QuestionOpenDomainService>()
+
+    private lateinit var questionDomainService: QuestionDomainService
+
+    @BeforeEach
+    fun setup() {
+        questionDomainService = QuestionDomainService(
+            questionCategoryRepository,
+            questionRepository,
+            questionOpenRepository,
+            userRepository,
+            userCustomizedQuestionCategoryRepository,
+            questionOpenDomainService
+        )
+    }
+
+    @Nested
+    inner class GetQuestion {
+        private lateinit var user: UserEntity
+        private lateinit var question1: QuestionEntity
+        private lateinit var question2: QuestionEntity
+
+        @BeforeEach
+        fun setup() {
+            user = MemberFixture.createMember(1)
+            question1 = QuestionFixture.createQuestion(1)
+            question2 = QuestionFixture.createQuestion(2)
+            val questionCategory = QuestionFixture.createQuestionCategory(1)
+
+            every { userRepository.findByIdOrNull(1) } returns user
+            every { questionRepository.findByIdOrNull(1) } returns question1
+            every { questionRepository.findByIdOrNull(2) } returns question2
+            every { questionCategoryRepository.findByIdOrNull(any()) } returns questionCategory
+        }
+
+        @Test
+        fun `SCCESS - 문제 가져오기 성공`() {
+            // given
+            val issuedQuestion = QuestionFixture.createQuestionOpen(1, question1, user = user)
+            every { questionOpenRepository.findByQuestionAndUser(question1, user) } returns issuedQuestion
+
+            // when
+            val question = questionDomainService.getQuestion(user.id, question1.id)
+
+            // then
+            assertEquals(question.questionId, question1.id)
+            verify { questionOpenRepository.findByQuestionAndUser(question1, user) }
+        }
+
+        @Test
+        fun `FAIL - 발급 받지 않은 문제 요청`() {
+            // given
+            every { questionOpenRepository.findByQuestionAndUser(question1, user) } returns null
+
+            // when, then
+            assertThrows<QuestionNotOpenedException> {
+                questionDomainService.getQuestion(user.id, question1.id)
+            }
+
+            verify { questionOpenRepository.findByQuestionAndUser(question1, user) }
+        }
+    }
+
+    @Nested
+    inner class GetOrCreateTodayQuestion {
+        private lateinit var user: UserEntity
+        private lateinit var question1: QuestionEntity
+        private lateinit var question2: QuestionEntity
+
+        @BeforeEach
+        fun setup() {
+            user = MemberFixture.createMember(1)
+            question1 = QuestionFixture.createQuestion(1)
+            question2 = QuestionFixture.createQuestion(2)
+            val questionCategory = QuestionFixture.createQuestionCategory(1)
+
+            every { userRepository.findByIdOrNull(1) } returns user
+            every { questionCategoryRepository.findByIdOrNull(any()) } returns questionCategory
+        }
+
+        @Test
+        fun `SUCCESS - 문제 발급 & 응답`() {
+            val today = LocalDate.now()
+            val latestIssuedQuestion =
+                QuestionFixture.createQuestionOpen(1, question1, user = user, openDate = LocalDateTime.now().minusDays(1))
+            val newIssuedQuestionInfo = QuestionFixture.createQuestionInfo(questionId = question2.id)
+            every { questionOpenRepository.findLatest(user) } returns latestIssuedQuestion
+            every { questionOpenDomainService.issueQuestion(user.id , today) } returns newIssuedQuestionInfo
+
+            val questionInfo = questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(user.id, today))
+
+            assertEquals(questionInfo.questionId, question2.id)
+
+            verify { questionOpenRepository.findLatest(user) }
+            verify { questionOpenDomainService.issueQuestion(any(), any()) }
+        }
+
+        @Test
+        fun `SUCCESS - 기존 문제 응답`() {
+            val latestIssuedQuestion =
+                QuestionFixture.createQuestionOpen(1, question1, user = user, openDate = LocalDateTime.now())
+            val newIssuedQuestionInfo = QuestionFixture.createQuestionInfo(questionId = question2.id)
+            every { questionOpenRepository.findLatest(user) } returns latestIssuedQuestion
+            every { questionOpenDomainService.issueQuestion(any(), any()) } returns newIssuedQuestionInfo
+
+            val questionInfo = questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(1, LocalDate.now()))
+
+            assertEquals(questionInfo.questionId, question1.id)
+
+            verify { questionOpenRepository.findLatest(user) }
+            verify(exactly = 0) { questionOpenDomainService.issueQuestion(any(), any()) }
+        }
+    }
+}

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainServiceUnitTest.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainServiceUnitTest.kt
@@ -1,0 +1,129 @@
+package com.adevspoon.domain.techQuestion.service
+
+import com.adevspoon.domain.fixture.MemberFixture
+import com.adevspoon.domain.fixture.QuestionFixture
+import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.exception.QuestionExhaustedException
+import com.adevspoon.domain.techQuestion.repository.QuestionCategoryRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
+import com.adevspoon.domain.techQuestion.repository.QuestionRepository
+import com.adevspoon.domain.techQuestion.repository.UserCustomizedQuestionCategoryRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
+
+class QuestionOpenDomainServiceUnitTest {
+    private val questionCategoryRepository = mockk<QuestionCategoryRepository>()
+    private val questionOpenRepository = mockk<QuestionOpenRepository>()
+    private val questionRepository = mockk<QuestionRepository>()
+    private val userRepository = mockk<UserRepository>()
+    private val userCustomizedQuestionCategoryRepository = mockk<UserCustomizedQuestionCategoryRepository>()
+
+    private lateinit var questionOpenDomainService: QuestionOpenDomainService
+
+    @BeforeEach
+    fun setUp() {
+        questionOpenDomainService = QuestionOpenDomainService(
+            questionCategoryRepository,
+            questionOpenRepository,
+            questionRepository,
+            userRepository,
+            userCustomizedQuestionCategoryRepository
+        )
+    }
+
+    @Nested
+    inner class IssueQuestion() {
+        private lateinit var member: UserEntity
+        private lateinit var question: QuestionEntity
+        private lateinit var questionOpen: QuestionOpenEntity
+        private lateinit var questionCategory: QuestionCategoryEntity
+
+        @BeforeEach
+        fun setup() {
+            member = MemberFixture.createMember(1)
+            question = QuestionFixture.createQuestion(1)
+            questionOpen = QuestionFixture.createQuestionOpen(1, question, user = member)
+            questionCategory = QuestionFixture.createQuestionCategory(1)
+
+            every { userRepository.findByIdOrNull(any()) } returns member
+            every { userCustomizedQuestionCategoryRepository.findAllSelectedCategoryIds(any()) } returns listOf(1, 2)
+            every { questionCategoryRepository.findAllIds() } returns listOf(1, 2)
+
+            every { questionRepository.findByIdOrNull(any()) } returns question
+            every { questionOpenRepository.save(any()) } returns questionOpen
+            every { questionCategoryRepository.findByIdOrNull(any()) } returns questionCategory
+        }
+
+        @Test
+        fun `SUCCESS - 새로운 문제 발급 성공(커먼 케이스)`() {
+            // given
+            every { questionOpenRepository.findAllIssuedQuestionIds(any()) } returns setOf(3,4)
+            every { questionRepository.findAllQuestionIds(any()) } returns setOf(1,2,3,4)
+
+            // when
+            val issueQuestion = questionOpenDomainService.issueQuestion(member.id, LocalDate.now())
+
+            // then
+            assertEquals(question.id, issueQuestion.questionId)
+            assertEquals(false, issueQuestion.isLast)
+
+            verify { userCustomizedQuestionCategoryRepository.findAllSelectedCategoryIds(any()) }
+            verify(exactly = 0) { questionCategoryRepository.findAllIds() }
+
+            verify { questionRepository.findAllQuestionIds(any()) }
+            verify { questionOpenRepository.findAllIssuedQuestionIds(any()) }
+        }
+
+        @Test
+        fun `SUCCESS - 새로운 문제발급 성공(마지막 문제 발급)`() {
+            // given
+            every { questionOpenRepository.findAllIssuedQuestionIds(any()) } returns setOf(3,4)
+            every { questionRepository.findAllQuestionIds(any()) } returns setOf(1,3,4)
+
+            // when
+            val issueQuestion = questionOpenDomainService.issueQuestion(member.id, LocalDate.now())
+
+            // then
+            assertEquals(question.id, issueQuestion.questionId)
+            assertEquals(true, issueQuestion.isLast)
+
+            verify { userCustomizedQuestionCategoryRepository.findAllSelectedCategoryIds(any()) }
+            verify(exactly = 0) { questionCategoryRepository.findAllIds() }
+
+            verify { questionRepository.findAllQuestionIds(any()) }
+            verify { questionOpenRepository.findAllIssuedQuestionIds(any()) }
+        }
+
+        @Test
+        fun `FAIL - 문제 고갈`() {
+            // given
+            every { questionOpenRepository.findAllIssuedQuestionIds(any()) } returns setOf(3,4)
+            every { questionRepository.findAllQuestionIds(any()) } returns setOf(3,4)
+
+            // when, then
+            assertThrows<QuestionExhaustedException> {
+                questionOpenDomainService.issueQuestion(member.id, LocalDate.now())
+            }
+
+            verify { userCustomizedQuestionCategoryRepository.findAllSelectedCategoryIds(any()) }
+            verify(exactly = 0) { questionCategoryRepository.findAllIds() }
+
+            verify { questionRepository.findAllQuestionIds(any()) }
+            verify { questionOpenRepository.findAllIssuedQuestionIds(any()) }
+
+            verify(exactly = 0) { questionOpenRepository.save(any()) }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,7 @@ subprojects {
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
         implementation("org.springframework.boot:spring-boot-starter-validation")
+        implementation("org.springframework.boot:spring-boot-starter-aop")
 
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("io.mockk:mockk:1.13.7")


### PR DESCRIPTION

### Issue
- close #15
- close #33

### Summary
- 질문 id 기반 조회 API
- 오늘의 질문 조회 API(없으면 발급)
- 분산락(기존 MySQL의 Named Lock 이용) - 별도 데이터소스, AOP 구현

### Description
질문 발급 시 동시성 이슈 차단을 위해 분산락 구현했습니다.
분산락 키는 메서드의 파라미터가 LockKey 인터페이스를 구현하도록 했고, 현재는 기존 사용중인 MySQL의 NamedLock으로 만들었습니다.