### PR TITLE
Feat/#39. 질문 카테고리 리스트 API 구현(고갈, 선택 여부 포함)

### DIFF
--- a/adevspoon-api/build.gradle.kts
+++ b/adevspoon-api/build.gradle.kts
@@ -17,8 +17,6 @@ dependencies {
     implementation(project(":adevspoon-infrastructure"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework:spring-tx")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/dto/request/MemberProfileUpdateRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/dto/request/MemberProfileUpdateRequest.kt
@@ -2,12 +2,14 @@ package com.adevspoon.api.member.dto.request
 
 import com.adevspoon.domain.member.dto.request.MemberUpdateRequireDto
 import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
 import org.springframework.web.multipart.MultipartFile
 
 data class MemberProfileUpdateRequest(
     @Schema(description = "수정할 이미지 파일")
     val image: MultipartFile?,
     val fcmToken: String?,
+    @field:Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
     val nickname: String?,
     @Schema(description = "수정할 대표 뱃지 id", example = "1")
     val representativeBadge: Int?,

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionController.kt
@@ -46,9 +46,6 @@ class QuestionController(
         @RequestUser user: RequestUserInfo,
         @Valid request: QuestionCategoryListRequest
     ): List<QuestionCategoryResponse> {
-        TODO("""
-            - limit 기본값 30개, offset 기본값 0개
-            - Category 가져오기 - 내가 선택한 카테고리인지, 더 이상 받을 질문이 없는지도 체크
-        """.trimIndent())
+        return questionService.getQuestionCategories(user.userId)
     }
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/response/QuestionCategoryResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/response/QuestionCategoryResponse.kt
@@ -1,12 +1,24 @@
 package com.adevspoon.api.question.dto.response
 
+import com.adevspoon.domain.techQuestion.dto.response.QuestionCategoryInfo
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class QuestionCategoryResponse(
     val id: Long,
     val name: String,
-    @Schema(description = "현재 유저기준 해당 카테고리에 더 이상 받을 질문이 없는지 여부")
+    @Schema(description = "현재 유저가 해당 카테고리에 더 이상 받을 질문이 없는지 여부")
     val depleted: Boolean,
     @Schema(description = "현재 선택한 카테고리인지 여부")
     val selected: Boolean
-)
+) {
+    companion object {
+        fun from(info: QuestionCategoryInfo): QuestionCategoryResponse {
+            return QuestionCategoryResponse(
+                id = info.id,
+                name = info.name,
+                depleted = info.depleted,
+                selected = info.selected
+            )
+        }
+    }
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
@@ -1,6 +1,7 @@
 package com.adevspoon.api.question.service
 
 import com.adevspoon.api.common.annotation.ApplicationService
+import com.adevspoon.api.question.dto.response.QuestionCategoryResponse
 import com.adevspoon.api.question.dto.response.QuestionInfoResponse
 import com.adevspoon.domain.techQuestion.dto.request.GetTodayQuestion
 import com.adevspoon.domain.techQuestion.service.QuestionDomainService
@@ -21,6 +22,13 @@ class QuestionService(
         return questionDomainService.getQuestion(memberId, questionId)
             .let {
                 QuestionInfoResponse.from(it)
+            }
+    }
+
+    fun getQuestionCategories(memberId: Long): List<QuestionCategoryResponse> {
+        return questionDomainService.getQuestionCategories(memberId)
+            .map {
+                QuestionCategoryResponse.from(it)
             }
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/UserCustomizedQuestionCategoryEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/UserCustomizedQuestionCategoryEntity.kt
@@ -20,10 +20,10 @@ class UserCustomizedQuestionCategoryId(
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "categoryId", nullable = false)
-    val category: QuestionCategoryEntity? = null,
+    val category: QuestionCategoryEntity,
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "userId", nullable = false)
-    val user: UserEntity? = null
+    val user: UserEntity
 ): Serializable

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/CategoryQuestionCountDto.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/CategoryQuestionCountDto.kt
@@ -1,0 +1,21 @@
+package com.adevspoon.domain.techQuestion.dto.response
+
+data class CategoryQuestionCountDto(
+    val categoryId: Long,
+    val questionCount: Long
+) {
+    operator fun minus(right: CategoryQuestionCountDto): CategoryQuestionCountDto {
+        if (categoryId != right.categoryId) return this
+        return CategoryQuestionCountDto(categoryId, questionCount - right.questionCount)
+    }
+
+    val isDepleted: Boolean = questionCount <= 0
+}
+
+fun List<CategoryQuestionCountDto>.subtractCount(right: List<CategoryQuestionCountDto>): List<CategoryQuestionCountDto> {
+    return this.map { left ->
+        right.find { it.categoryId == left.categoryId }?.let { right ->
+            left - right
+        } ?: left
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/QuestionCategoryInfo.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/QuestionCategoryInfo.kt
@@ -1,0 +1,16 @@
+package com.adevspoon.domain.techQuestion.dto.response
+
+import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
+
+data class QuestionCategoryInfo(
+    val id: Long,
+    val name: String,
+    val depleted: Boolean = false,
+    val selected: Boolean = false
+) {
+    companion object {
+        fun from(category: QuestionCategoryEntity, depleted: Boolean, selected: Boolean): QuestionCategoryInfo {
+            return QuestionCategoryInfo(category.id, category.category, depleted, selected)
+        }
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
@@ -3,6 +3,7 @@ package com.adevspoon.domain.techQuestion.repository
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.dto.response.CategoryQuestionCountDto
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -25,4 +26,10 @@ interface QuestionOpenRepository: JpaRepository<QuestionOpenEntity, Long> {
 
     @Query("SELECT qo.question.id FROM QuestionOpenEntity qo WHERE qo.user = :user")
     fun findAllIssuedQuestionIds(user: UserEntity): Set<Long>
+
+    @Query("SELECT new com.adevspoon.domain.techQuestion.dto.response.CategoryQuestionCountDto(q.question.categoryId, COUNT(q)) " +
+            "FROM QuestionOpenEntity q " +
+            "WHERE q.user = :user " +
+            "GROUP BY q.question.categoryId ")
+    fun findIssuedQuestionGroupByCategory(user: UserEntity): List<CategoryQuestionCountDto>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionRepository.kt
@@ -1,10 +1,16 @@
 package com.adevspoon.domain.techQuestion.repository
 
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
+import com.adevspoon.domain.techQuestion.dto.response.CategoryQuestionCountDto
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface QuestionRepository: JpaRepository<QuestionEntity, Long> {
     @Query("SELECT q.id from QuestionEntity q where q.categoryId in :categoryIds")
     fun findAllQuestionIds(categoryIds: List<Long>): Set<Long>
+
+    @Query("SELECT new com.adevspoon.domain.techQuestion.dto.response.CategoryQuestionCountDto(q.categoryId, COUNT(q)) " +
+            "FROM QuestionEntity q " +
+            "GROUP BY q.categoryId")
+    fun findQuestionCountGroupByCategory(): List<CategoryQuestionCountDto>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/UserCustomizedQuestionCategoryRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/UserCustomizedQuestionCategoryRepository.kt
@@ -1,6 +1,7 @@
 package com.adevspoon.domain.techQuestion.repository
 
 import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.UserCustomizedQuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.UserCustomizedQuestionCategoryId
 import org.springframework.data.jpa.repository.JpaRepository
@@ -15,4 +16,7 @@ interface UserCustomizedQuestionCategoryRepository: JpaRepository<UserCustomized
 
     @Query("select qc.id.category.id from UserCustomizedQuestionCategoryEntity qc where qc.id.user = :user")
     fun findAllSelectedCategoryIds(user: UserEntity): List<Long>
+
+    @Query("select qc.id.category from UserCustomizedQuestionCategoryEntity qc where qc.id.user = :user")
+    fun findAllSelectedCategory(user: UserEntity): List<QuestionCategoryEntity>
 }

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
@@ -5,6 +5,7 @@ import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
 import com.adevspoon.domain.techQuestion.domain.enums.QuestionCategoryTopic
+import com.adevspoon.domain.techQuestion.dto.response.CategoryQuestionCountDto
 import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -85,6 +86,13 @@ class QuestionFixture {
             isLast = isLast,
             createdAt = createdAt,
             updatedAt = updatedAt,
+        )
+
+        fun createQuestionCount(
+            categoryId: Long = 1,
+            questionCount: Long = 1,
+        ) = CategoryQuestionCountDto(
+            categoryId, questionCount
         )
     }
 }

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/fixture/QuestionFixture.kt
@@ -6,6 +6,7 @@ import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
 import com.adevspoon.domain.techQuestion.domain.enums.QuestionCategoryTopic
 import com.adevspoon.domain.techQuestion.dto.response.CategoryQuestionCountDto
+import com.adevspoon.domain.techQuestion.dto.response.QuestionCategoryInfo
 import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -93,6 +94,15 @@ class QuestionFixture {
             questionCount: Long = 1,
         ) = CategoryQuestionCountDto(
             categoryId, questionCount
+        )
+
+        fun createQuestionCategoryInfo(
+            id: Long = 1,
+            depleted: Boolean = false,
+            selected: Boolean = false,
+            name: String = "name",
+        ) = QuestionCategoryInfo(
+            id, name, depleted, selected
         )
     }
 }

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceUnitTest.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceUnitTest.kt
@@ -4,6 +4,7 @@ import com.adevspoon.domain.fixture.MemberFixture
 import com.adevspoon.domain.fixture.QuestionFixture
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import com.adevspoon.domain.techQuestion.dto.request.GetTodayQuestion
 import com.adevspoon.domain.techQuestion.exception.QuestionNotOpenedException
@@ -141,6 +142,66 @@ class QuestionDomainServiceUnitTest {
 
             verify { questionOpenRepository.findLatest(user) }
             verify(exactly = 0) { questionOpenDomainService.issueQuestion(any(), any()) }
+        }
+    }
+
+    @Nested
+    inner class GetQuestionCategories {
+        private lateinit var user: UserEntity
+        private lateinit var questionCategory1: QuestionCategoryEntity
+        private lateinit var questionCategory2: QuestionCategoryEntity
+        private lateinit var questionCategory3: QuestionCategoryEntity
+        private lateinit var question1: QuestionEntity
+        private lateinit var question2: QuestionEntity
+        private lateinit var question3: QuestionEntity
+        private lateinit var question4: QuestionEntity
+
+        @BeforeEach
+        fun setup() {
+            user = MemberFixture.createMember(1)
+            questionCategory1 = QuestionFixture.createQuestionCategory(1)
+            questionCategory2 = QuestionFixture.createQuestionCategory(2)
+            questionCategory3 = QuestionFixture.createQuestionCategory(3)
+            question1 = QuestionFixture.createQuestion(1, categoryId = 1)
+            question2 = QuestionFixture.createQuestion(1, categoryId = 1)
+            question3 = QuestionFixture.createQuestion(1, categoryId = 2)
+            question4 = QuestionFixture.createQuestion(1, categoryId = 3)
+
+            every { userRepository.findByIdOrNull(1) } returns user
+        }
+
+        @Test
+        fun `SUCCESS - 사용자의 문제 카테고리 가져오기 (고갈, 선택 포함)`() {
+            // given
+            every { questionCategoryRepository.findAll() } returns listOf(questionCategory1, questionCategory2, questionCategory3)
+            every { userCustomizedQuestionCategoryRepository.findAllSelectedCategory(user) } returns listOf(questionCategory1, questionCategory2)
+
+            every { questionRepository.findQuestionCountGroupByCategory() } returns listOf(
+                QuestionFixture.createQuestionCount(1, 2),
+                QuestionFixture.createQuestionCount(2, 1),
+                QuestionFixture.createQuestionCount(3, 1),
+            )
+            every { questionOpenRepository.findIssuedQuestionGroupByCategory(user) } returns listOf(
+                QuestionFixture.createQuestionCount(1, 2),
+            )
+
+            // when
+            var categories = questionDomainService.getQuestionCategories(user.id)
+            categories = categories.sortedWith(compareBy { it.id })
+
+            // then
+            assertEquals(categories.size, 3, "문제 카테고리 개수는 총 3개")
+            assertEquals(categories[0].id, 1L)
+            assertEquals(categories[0].depleted, true, "카테고리 1은 문제 고갈됨")
+            assertEquals(categories[0].selected, true, "카테고리 1은 선택됨")
+
+            assertEquals(categories[1].id, 2L)
+            assertEquals(categories[1].depleted, false, "카테고리 2는 고갈되지 않음")
+            assertEquals(categories[1].selected, true, "카테고리 2는 선택됨")
+
+            assertEquals(categories[2].id, 3L)
+            assertEquals(categories[2].depleted, false, "카테고리 3은 고갈되지 않음")
+            assertEquals(categories[2].selected, false, "카테고리 3은 선택하지 않음")
         }
     }
 }

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceUnitTest.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceUnitTest.kt
@@ -115,10 +115,15 @@ class QuestionDomainServiceUnitTest {
         fun `SUCCESS - 문제 발급 & 응답`() {
             val today = LocalDate.now()
             val latestIssuedQuestion =
-                QuestionFixture.createQuestionOpen(1, question1, user = user, openDate = LocalDateTime.now().minusDays(1))
+                QuestionFixture.createQuestionOpen(
+                    1,
+                    question1,
+                    user = user,
+                    openDate = LocalDateTime.now().minusDays(1)
+                )
             val newIssuedQuestionInfo = QuestionFixture.createQuestionInfo(questionId = question2.id)
             every { questionOpenRepository.findLatest(user) } returns latestIssuedQuestion
-            every { questionOpenDomainService.issueQuestion(user.id , today) } returns newIssuedQuestionInfo
+            every { questionOpenDomainService.issueQuestion(user.id, today) } returns newIssuedQuestionInfo
 
             val questionInfo = questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(user.id, today))
 
@@ -173,8 +178,15 @@ class QuestionDomainServiceUnitTest {
         @Test
         fun `SUCCESS - 사용자의 문제 카테고리 가져오기 (고갈, 선택 포함)`() {
             // given
-            every { questionCategoryRepository.findAll() } returns listOf(questionCategory1, questionCategory2, questionCategory3)
-            every { userCustomizedQuestionCategoryRepository.findAllSelectedCategory(user) } returns listOf(questionCategory1, questionCategory2)
+            every { questionCategoryRepository.findAll() } returns listOf(
+                questionCategory1,
+                questionCategory2,
+                questionCategory3
+            )
+            every { userCustomizedQuestionCategoryRepository.findAllSelectedCategory(user) } returns listOf(
+                questionCategory1,
+                questionCategory2
+            )
 
             every { questionRepository.findQuestionCountGroupByCategory() } returns listOf(
                 QuestionFixture.createQuestionCount(1, 2),
@@ -186,22 +198,19 @@ class QuestionDomainServiceUnitTest {
             )
 
             // when
-            var categories = questionDomainService.getQuestionCategories(user.id)
-            categories = categories.sortedWith(compareBy { it.id })
+            val categories = questionDomainService.getQuestionCategories(user.id).sortedWith(compareBy { it.id })
 
             // then
-            assertEquals(categories.size, 3, "문제 카테고리 개수는 총 3개")
-            assertEquals(categories[0].id, 1L)
-            assertEquals(categories[0].depleted, true, "카테고리 1은 문제 고갈됨")
-            assertEquals(categories[0].selected, true, "카테고리 1은 선택됨")
+            val expected = mutableListOf(
+                QuestionFixture.createQuestionCategoryInfo(id = 1, depleted = true, selected = true),
+                QuestionFixture.createQuestionCategoryInfo(id = 2, depleted = false, selected = true),
+                QuestionFixture.createQuestionCategoryInfo(id = 3, depleted = false, selected = false)
+            )
 
-            assertEquals(categories[1].id, 2L)
-            assertEquals(categories[1].depleted, false, "카테고리 2는 고갈되지 않음")
-            assertEquals(categories[1].selected, true, "카테고리 2는 선택됨")
-
-            assertEquals(categories[2].id, 3L)
-            assertEquals(categories[2].depleted, false, "카테고리 3은 고갈되지 않음")
-            assertEquals(categories[2].selected, false, "카테고리 3은 선택하지 않음")
+            expected.forEachIndexed { idx, info ->
+                assertEquals(categories[idx].depleted, info.depleted)
+                assertEquals(categories[idx].selected, info.selected)
+            }
         }
     }
 }


### PR DESCRIPTION

### Issue 
- close #39

### Summary
- 질문 카테고리 리스트를 가져오는 API 구현(각 카테고리별 선택여부 ,질문 고갈 여부 포함)

### Description
- limit, offset이 쿼리에 포함되어 있지만 현재 정책상 모든 카테고리를 넘기기 때문에 일단 무시하고 처리했습니다.