### PR TITLE
Feat/#45. 답변 등록 시 활동이벤트 AOP 처리(UserActivity 업데이트 및 뱃지 획득)

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionController.kt
@@ -32,7 +32,7 @@ class QuestionController(
     }
 
     @Operation(summary = "질문 id 기반으로 상세정보 가져오기")
-    @GetMapping("/question/{questionId}")
+    @GetMapping("/{questionId}")
     fun getQuestionDetail(
         @RequestUser user: RequestUserInfo,
         @PathVariable questionId: Long,
@@ -41,7 +41,7 @@ class QuestionController(
     }
 
     @Operation(summary = "질문 카테고리 리스트 가져오기")
-    @GetMapping("/question/category")
+    @GetMapping("/category")
     fun getQuestionCategoryList(
         @RequestUser user: RequestUserInfo,
         @Valid request: QuestionCategoryListRequest

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainErrorCode.kt
@@ -11,5 +11,6 @@ enum class PostDomainErrorCode(
 ): AdevspoonErrorCode {
     BOARD_TAG_NOT_FOUND(domain code 404 no 0, "등록되지 않은 태그입니다."),
     BOARD_POST_NOT_FOUND(domain code 404 no 1, "등록되지 않은 게시글입니다."),
-    BOARD_POST_EDIT_UNAUTHORIZED(domain code 403 no 0, "해당 게시글에 권한이 없습니다.");
+    BOARD_POST_EDIT_UNAUTHORIZED(domain code 403 no 0, "해당 게시글에 권한이 없습니다."),
+    BOARD_POST_INVALID_RETURN(domain code 500 no 0, "게시글 등록 중 오류가 발생했습니다.");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainException.kt
@@ -12,3 +12,4 @@ class BoardPostNotFoundException(postId: String): AdevspoonException(
 class BoardPostOwnershipException(postOwnerId: String, loginUserId: String): AdevspoonException(
     BOARD_POST_EDIT_UNAUTHORIZED,
     detailReason = BOARD_POST_EDIT_UNAUTHORIZED.message + " postOwnerId: $postOwnerId, loginUserId: $loginUserId")
+class BoardPostInvalidReturnException: AdevspoonException(BOARD_POST_INVALID_RETURN)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/aop/ActivityEventAdvisor.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/aop/ActivityEventAdvisor.kt
@@ -1,9 +1,13 @@
 package com.adevspoon.domain.common.aop
 
 import com.adevspoon.domain.board.dto.response.BoardPost
+import com.adevspoon.domain.board.exception.BoardPostInvalidReturnException
 import com.adevspoon.domain.common.annotation.ActivityEvent
 import com.adevspoon.domain.common.annotation.ActivityEventType
+import com.adevspoon.domain.common.event.AnswerActivityEvent
 import com.adevspoon.domain.common.event.BoardPostActivityEvent
+import com.adevspoon.domain.techQuestion.dto.response.QuestionAnswerInfo
+import com.adevspoon.domain.techQuestion.exception.QuestionAnswerInvalidReturnException
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.annotation.AfterReturning
 import org.aspectj.lang.annotation.Aspect
@@ -36,9 +40,10 @@ class ActivityEventAdvisor(
             .getAnnotation(ActivityEvent::class.java)
 
     private fun boardPostEventPublish(result: Any?) {
-        (result as? BoardPost)?.let {
-            eventPublisher.publishEvent(BoardPostActivityEvent(it.user.memberId))
-        }
+        (result as? BoardPost)
+            ?.let {
+                eventPublisher.publishEvent(BoardPostActivityEvent(it.user.memberId))
+            } ?: throw BoardPostInvalidReturnException()
     }
 
     private fun attendanceEventPublish(result: Any?) {
@@ -48,8 +53,9 @@ class ActivityEventAdvisor(
     }
 
     private fun answerEventPublish(result: Any?) {
-        TODO("""
-            Implement the logic to publish the ANSWER event
-        """.trimIndent())
+        (result as? QuestionAnswerInfo)
+            ?.let {
+                eventPublisher.publishEvent(AnswerActivityEvent(it.user.memberId, it.answerId))
+            } ?: throw QuestionAnswerInvalidReturnException()
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/AsyncConfig.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/AsyncConfig.kt
@@ -1,8 +1,9 @@
 package com.adevspoon.domain.config
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
 import org.springframework.scheduling.annotation.EnableAsync
 
 @Configuration
-@EnableAsync
+@EnableAsync(order = Ordered.LOWEST_PRECEDENCE - 11) // 트랜잭션 AOP보다 먼저 처리
 class AsyncConfig

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberActivityEventHandler.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberActivityEventHandler.kt
@@ -59,11 +59,11 @@ class MemberActivityEventHandler(
                 val answeredDateList = answerRepository.findAnsweredDateList(event.memberId)
                     .map { it.toLocalDate() }
 
-                // 이전날 답변이 있으면 += 1, 아니면 1로 초기화
                 cumulativeAnswerCount += 1
                 consecutiveAnswerCount =
-                    if (consecutiveAnswerCount == 0 || answeredDateList.size <= 1) 1
-                    else if (answeredDateList[0].until(answeredDateList[1], ChronoUnit.DAYS) == 1L) consecutiveAnswerCount + 1
+                    if (answeredDateList.size > 1 &&
+                        answeredDateList[0].until(answeredDateList[1], ChronoUnit.DAYS) == 1L)
+                        consecutiveAnswerCount + 1
                     else 1
                 maxConsecutiveAnswerCount = maxOf(maxConsecutiveAnswerCount, consecutiveAnswerCount)
             }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberActivityEventHandler.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberActivityEventHandler.kt
@@ -4,17 +4,30 @@ import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.common.event.AnswerActivityEvent
 import com.adevspoon.domain.common.event.AttendanceActivityEvent
 import com.adevspoon.domain.common.event.BoardPostActivityEvent
+import com.adevspoon.domain.member.domain.UserActivityEntity
+import com.adevspoon.domain.member.domain.UserBadgeAcheiveEntity
+import com.adevspoon.domain.member.domain.UserBadgeAcheiveId
+import com.adevspoon.domain.member.exception.MemberNotFoundException
+import com.adevspoon.domain.member.repository.BadgeRepository
 import com.adevspoon.domain.member.repository.UserActivityRepository
+import com.adevspoon.domain.member.repository.UserBadgeAchieveRepository
+import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.repository.AnswerRepository
 import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.scheduling.annotation.Async
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
+import java.time.temporal.ChronoUnit
 
 @DomainService
 class MemberActivityEventHandler(
+    private val userRepository: UserRepository,
     private val userActivityRepository: UserActivityRepository,
+    private val userBadgeAchieveRepository: UserBadgeAchieveRepository,
+    private val answerRepository: AnswerRepository,
+    private val badgeRepository: BadgeRepository,
 ) {
-
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional
@@ -28,9 +41,8 @@ class MemberActivityEventHandler(
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional
     fun handleAnswerEvent(event: AnswerActivityEvent) {
-        TODO("""
-            Implement the logic to handle the ANSWER event
-        """.trimIndent())
+        val updatedUserActivity = updateUserActivity(event)
+        acquireNewBadges(updatedUserActivity, event)
     }
 
     @Async
@@ -38,5 +50,47 @@ class MemberActivityEventHandler(
     @Transactional
     fun handleBoardPostEvent(event: BoardPostActivityEvent) {
         userActivityRepository.increaseBoardPostCount(event.memberId)
+    }
+
+    private fun updateUserActivity(event: AnswerActivityEvent): UserActivityEntity {
+        return userActivityRepository.findById(event.memberId)
+            .orElseThrow { MemberNotFoundException() }
+            .apply {
+                val answeredDateList = answerRepository.findAnsweredDateList(event.memberId)
+                    .map { it.toLocalDate() }
+
+                // 이전날 답변이 있으면 += 1, 아니면 1로 초기화
+                cumulativeAnswerCount += 1
+                consecutiveAnswerCount =
+                    if (consecutiveAnswerCount == 0 || answeredDateList.size <= 1) 1
+                    else if (answeredDateList[0].until(answeredDateList[1], ChronoUnit.DAYS) == 1L) consecutiveAnswerCount + 1
+                    else 1
+                maxConsecutiveAnswerCount = maxOf(maxConsecutiveAnswerCount, consecutiveAnswerCount)
+            }
+            .let(userActivityRepository::save)
+    }
+
+    private fun acquireNewBadges(userActivity: UserActivityEntity, event: AnswerActivityEvent) {
+        val user = userRepository.findByIdOrNull(event.memberId) ?: throw MemberNotFoundException()
+        val notAchievedBadges = badgeRepository.findAll()
+            .also { badgeList ->
+                val achievedBadges = userBadgeAchieveRepository.findUserBadgeList(event.memberId)
+                badgeList.removeAll { badge -> achievedBadges.any { badge.id == it.id } }
+            }
+        val newAchieveBadges = notAchievedBadges.filter {
+            when(it.criteria) {
+                userActivity::cumulativeAnswerCount.name ->
+                    (it.criteriaValue ?: 0) <= userActivity.cumulativeAnswerCount
+                userActivity::maxConsecutiveAnswerCount.name ->
+                    (it.criteriaValue ?: 0) <= userActivity.maxConsecutiveAnswerCount
+                else -> false
+            }
+        }
+
+        userBadgeAchieveRepository.saveAll(
+            newAchieveBadges.map { badge ->
+                UserBadgeAcheiveEntity(UserBadgeAcheiveId(user = user, badge = badge))
+            }
+        )
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
@@ -15,4 +15,6 @@ enum class QuestionDomainErrorCode(
 
     QUESTION_NOT_FOUND(domain code 404 no 0, "없는 Question ID로 조회 시도"),
     QUESTION_CATEGORY_NOT_FOUND(domain code 404 no 1, "없는 카테고리 ID로 등록 시도"),
+
+    QUESTION_ANSWER_INVALID_RETURN(domain code 500 no 0, "Answer 등록 중 오류가 발생했습니다"),
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
@@ -7,3 +7,5 @@ class QuestionExhaustedException : AdevspoonException(QuestionDomainErrorCode.QU
 
 class QuestionNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_NOT_FOUND)
 class QuestionCategoryNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_CATEGORY_NOT_FOUND)
+
+class QuestionAnswerInvalidReturnException : AdevspoonException(QuestionDomainErrorCode.QUESTION_ANSWER_INVALID_RETURN)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/AnswerRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/AnswerRepository.kt
@@ -2,7 +2,15 @@ package com.adevspoon.domain.techQuestion.repository
 
 import com.adevspoon.domain.techQuestion.domain.AnswerEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.sql.Date
 
 interface AnswerRepository: JpaRepository<AnswerEntity, Long> {
-
+    @Query("SELECT DATE(a.createdAt) " +
+            "FROM AnswerEntity a " +
+            "WHERE a.user.id = :userId " +
+            "GROUP BY DATE(a.createdAt) " +
+            "ORDER BY DATE(a.createdAt) DESC " +
+            "Limit 2")
+    fun findAnsweredDateList(userId: Long): List<Date>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
@@ -1,5 +1,7 @@
 package com.adevspoon.domain.techQuestion.service
 
+import com.adevspoon.domain.common.annotation.ActivityEvent
+import com.adevspoon.domain.common.annotation.ActivityEventType
 import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.exception.MemberNotFoundException
@@ -26,6 +28,7 @@ class AnswerDomainService(
     private val userRepository: UserRepository,
     private val memberDomainService: MemberDomainService,
 ) {
+    @ActivityEvent(type = ActivityEventType.ANSWER)
     @Transactional
     fun registerQuestionAnswer(request: CreateQuestionAnswer): QuestionAnswerInfo {
         val requestMember = getMember(request.requestMemberId)


### PR DESCRIPTION

### Issue 
- close #45

### Summary
- 답변 등록시 활동이벤트 AOP 처리 및 로직 구현

### Description
- Async AOP가 트랜잭션 AOP 보다 우선순위가 높아야해 처리해주었습니다.
- 답변 등록 이벤트에서는 UserActivity 업데이트, 이후 달성한 뱃지를 추가하는 로직까지 작성하였습니다.