### PR TITLE
Feat#59. 좋아요 시 엔티티의 좋아요 개수 증가, 취소 시 감소

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
@@ -79,7 +79,7 @@ class BoardController(
         @RequestUser requestUser: RequestUserInfo,
         @RequestBody @Valid request: LikeBoardContentRequest
     ): String {
-        return boardService.toggleLike(request, requestUser.userId)
+        return boardService.likeBoard(request, requestUser.userId)
     }
 
     @Operation(summary = "게시글 신고")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
@@ -22,7 +22,7 @@ class BoardService(
         return BoardInfoResponse.from(boardPost)
     }
 
-    fun getBoardPostsByTags(request: BoardListRequest, loginUserId: Long) : BoardListResponse  {
+    fun getBoardPostsByTags(request: BoardListRequest, loginUserId: Long): BoardListResponse {
         val pageWithCursor = boardPostDomainService.getBoardPostsWithCriteria(request.toGetPostListRequestDto(), loginUserId)
         return BoardListResponse.from(pageWithCursor.data, pageWithCursor.nextCursorId)
     }
@@ -37,9 +37,13 @@ class BoardService(
         return "Successfully delete. postId:${request.postId}"
     }
 
-    fun toggleLike(request: LikeBoardContentRequest, userId: Long) : String{
-        boardPostDomainService.toggleLike(request.toLikeStateRequest(), userId)
-        return "Successfully toggle like"
+    fun likeBoard(request: LikeBoardContentRequest, userId: Long): String {
+        val likeRequest = request.toLikeStateRequest()
+        val type = likeRequest.type
+        val contentId = likeRequest.contentId
+
+        boardPostDomainService.toggleLike(likeRequest, userId)
+        return if (likeRequest.like) "type:${type} contentId:${contentId} 좋아요 완료." else "type:${type} contentId:${contentId} 취소 완료."
     }
 
     fun report(request: ReportBoardContentRequest, userId: Long): String {

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
@@ -42,7 +42,7 @@ class BoardService(
         val type = likeRequest.type
         val contentId = likeRequest.contentId
 
-        boardPostDomainService.toggleLike(likeRequest, userId)
+        boardPostDomainService.toggleBoardLike(likeRequest, userId)
         return if (likeRequest.like) "type:${type} contentId:${contentId} 좋아요 완료." else "type:${type} contentId:${contentId} 취소 완료."
     }
 

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardCommentEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardCommentEntity.kt
@@ -1,5 +1,6 @@
 package com.adevspoon.domain.board.domain
 
+import com.adevspoon.domain.board.exception.NegativeLikeCountExceptionForBoard
 import com.adevspoon.domain.common.entity.BaseEntity
 import com.adevspoon.domain.member.domain.UserEntity
 import jakarta.persistence.*
@@ -33,4 +34,15 @@ class BoardCommentEntity(
     @NotNull
     @Column(name = "likeCount", nullable = false)
     var likeCount: Int = 0
-) : BaseEntity()
+) : BaseEntity() {
+    fun increaseLikeCount() {
+        this.likeCount++
+    }
+
+    fun decreaseLikeCount() {
+        if (likeCount - 1 < 0) {
+            throw NegativeLikeCountExceptionForBoard("board_comment", id)
+        }
+        this.likeCount--
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardPostEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardPostEntity.kt
@@ -1,5 +1,6 @@
 package com.adevspoon.domain.board.domain
 
+import com.adevspoon.domain.board.exception.NegativeLikeCountExceptionForBoard
 import com.adevspoon.domain.common.entity.BaseEntity
 import com.adevspoon.domain.member.domain.UserEntity
 import jakarta.persistence.*
@@ -49,6 +50,17 @@ class BoardPostEntity(
 ) : BaseEntity() {
     fun increaseViewCount() {
         this.viewCount++
+    }
+
+    fun increaseLikeCount() {
+        this.likeCount++
+    }
+
+    fun decreaseLikeCount() {
+        if (likeCount - 1 < 0) {
+            throw NegativeLikeCountExceptionForBoard("board_post", id)
+        }
+        this.likeCount--
     }
 
     fun updateTitleAndContent(title: String?, content: String?) {

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainErrorCode.kt
@@ -15,5 +15,6 @@ enum class PostDomainErrorCode(
     BOARD_POST_EDIT_UNAUTHORIZED(domain code 403 no 0, "해당 게시글에 권한이 없습니다."),
     BOARD_POST_INVALID_RETURN(domain code 500 no 0, "게시글 등록 중 오류가 발생했습니다."),
     SELF_REPORT_NOT_ALLOWED(domain code 403 no 1, "자기 게시글 혹은 댓글은 신고할 수 없습니다."),
-    ALREADY_REPORTED(domain code  409 no 0, "이미 신고가 접수된 게시글 혹은 댓글입니다.");
+    ALREADY_REPORTED(domain code 409 no 0, "이미 신고가 접수된 게시글 혹은 댓글입니다."),
+    MINIMUM_LIKE_COUNT(domain code 400 no 0, "좋아요 수는 음수일 수 없습니다.");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainErrorCode.kt
@@ -9,12 +9,16 @@ enum class PostDomainErrorCode(
     override val error: DomainType.Error,
     override val message: String,
 ): AdevspoonErrorCode {
+    MINIMUM_LIKE_COUNT(domain code 400 no 0, "좋아요 수는 음수일 수 없습니다."),
+
     BOARD_TAG_NOT_FOUND(domain code 404 no 0, "등록되지 않은 태그입니다."),
     BOARD_POST_NOT_FOUND(domain code 404 no 1, "등록되지 않은 게시글입니다."),
     BOARD_COMMENT_NOT_FOUND(domain code 404 no 2, "등록되지 않은 댓글입니다."),
+
     BOARD_POST_EDIT_UNAUTHORIZED(domain code 403 no 0, "해당 게시글에 권한이 없습니다."),
-    BOARD_POST_INVALID_RETURN(domain code 500 no 0, "게시글 등록 중 오류가 발생했습니다."),
     SELF_REPORT_NOT_ALLOWED(domain code 403 no 1, "자기 게시글 혹은 댓글은 신고할 수 없습니다."),
+
     ALREADY_REPORTED(domain code 409 no 0, "이미 신고가 접수된 게시글 혹은 댓글입니다."),
-    MINIMUM_LIKE_COUNT(domain code 400 no 0, "좋아요 수는 음수일 수 없습니다.");
+
+    BOARD_POST_INVALID_RETURN(domain code 500 no 0, "게시글 등록 중 오류가 발생했습니다.");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainException.kt
@@ -23,3 +23,8 @@ class SelfReportException : AdevspoonException(SELF_REPORT_NOT_ALLOWED)
 class DuplicateReportException(type: String, contentId: Long) : AdevspoonException(
     ALREADY_REPORTED,
     detailReason = ALREADY_REPORTED.message + " 신고된 content type: $type, id: $contentId")
+
+class NegativeLikeCountExceptionForBoard(type: String, contentId: Long) : AdevspoonException(
+    MINIMUM_LIKE_COUNT,
+    detailReason = MINIMUM_LIKE_COUNT.message + " type: $type, id: $contentId"
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
@@ -14,16 +14,18 @@ interface LikeRepository : JpaRepository<LikeEntity, Long>, JpaSpecificationExec
 
     fun findByUserAndAnswer(user: UserEntity, answer: AnswerEntity): LikeEntity?
 
+    fun findByUserAndBoardPostId(user: UserEntity, boardPostId: Long): LikeEntity?
+
+    fun findByUserAndBoardCommentId(user: UserEntity, boardCommentId: Long): LikeEntity?
+
     @Query("SELECT l.boardPostId FROM LikeEntity l WHERE l.user.id = :loginUserId AND l.boardPostId In :boardPostIds")
     fun findLikedPostIdsByUser(loginUserId: Long, boardPostIds: List<Long>): List<Long>
 
-    @Query("SELECT  l FROM  LikeEntity l " +
-        "WHERE l.user.id = :userId " +
-        "AND ((:type = 'board_post' AND l.boardPostId = :contentId) " +
-        "OR (:type = 'board_comment' AND l.boardCommentId = :contentId))")
-    fun findByTypeAndUserId(type: String, userId: Long, contentId: Long): LikeEntity?
-
-
     @Modifying(clearAutomatically = true)
     fun deleteAllByUserAndAnswer(user: UserEntity, answer: AnswerEntity)
+    @Modifying(clearAutomatically = true)
+    fun deleteAllByUserAndBoardPostId(user: UserEntity, boardPostId: Long)
+
+    @Modifying(clearAutomatically = true)
+    fun deleteAllByUserAndBoardCommentId(user: UserEntity, boardCommentId: Long)
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
@@ -23,9 +23,8 @@ interface LikeRepository : JpaRepository<LikeEntity, Long>, JpaSpecificationExec
 
     @Modifying(clearAutomatically = true)
     fun deleteAllByUserAndAnswer(user: UserEntity, answer: AnswerEntity)
-    @Modifying(clearAutomatically = true)
+
     fun deleteAllByUserAndBoardPostId(user: UserEntity, boardPostId: Long)
 
-    @Modifying(clearAutomatically = true)
     fun deleteAllByUserAndBoardCommentId(user: UserEntity, boardCommentId: Long)
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
@@ -33,13 +33,13 @@ class LikeDomainService(
         // FIXME : LikeEntity 나누기(Board, Comment, Answer), 각각 Unique Key 설정 필요 (현재 동시성을 못다룸 - 클라이언트에서만 처리)
         val likeEntity = likeRepository.findByUserAndAnswer(user, answer)
         if (!isLike && likeEntity != null) {
+            answer.decreaseLikeCount()
             likeRepository.deleteAllByUserAndAnswer(user, answer)
-            answer.likeCnt -= 1
         } else if (isLike && likeEntity == null) {
             likeRepository.save(
                 LikeEntity(user = user, postType = "answer", answer = answer)
             )
-            answer.likeCnt += 1
+            answer.increaseLikeCount()
         }
     }
 
@@ -47,13 +47,13 @@ class LikeDomainService(
     fun togglePostLike(post: BoardPostEntity, user: UserEntity, isLike: Boolean) {
         val likeEntity = likeRepository.findByUserAndBoardPostId(user, post.id)
         if (!isLike && likeEntity != null) {
+            post.decreaseLikeCount()
             likeRepository.deleteAllByUserAndBoardPostId(user, post.id)
-            post.likeCount -= 1
         } else if (isLike && likeEntity == null) {
             likeRepository.save(
                 LikeEntity(user = user, postType = "board_post", boardPostId = post.id)
             )
-            post.likeCount += 1
+            post.increaseLikeCount()
         }
     }
 
@@ -61,13 +61,13 @@ class LikeDomainService(
     fun toggleCommentLike(comment: BoardCommentEntity, user: UserEntity, isLike: Boolean) {
         val likeEntity = likeRepository.findByUserAndBoardCommentId(user, comment.id)
         if (!isLike && likeEntity != null) {
+            comment.decreaseLikeCount()
             likeRepository.deleteAllByUserAndBoardCommentId(user, comment.id)
-            comment.likeCount -= 1
         } else if (isLike && likeEntity == null) {
             likeRepository.save(
                 LikeEntity(user = user, postType = "board_comment", boardCommentId = comment.id)
             )
-            comment.likeCount += 1
+            comment.increaseLikeCount()
         }
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
@@ -6,14 +6,12 @@ import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.common.entity.LikeEntity
 import com.adevspoon.domain.common.repository.LikeRepository
 import com.adevspoon.domain.member.domain.UserEntity
-import com.adevspoon.domain.member.repository.UserRepository
 import com.adevspoon.domain.techQuestion.domain.AnswerEntity
 import org.springframework.transaction.annotation.Transactional
 
 @DomainService
 class LikeDomainService(
-    private val likeRepository: LikeRepository,
-    private val userRepository: UserRepository
+    private val likeRepository: LikeRepository
 ) {
     @Transactional
     fun isUserLikedPost(userId: Long, boardPostId: Long): Boolean {

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
@@ -2,8 +2,8 @@ package com.adevspoon.domain.member.service
 
 import com.adevspoon.common.dto.OAuthUserInfo
 import com.adevspoon.domain.common.annotation.DomainService
-import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.domain.UserActivityEntity
+import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.domain.enums.UserOAuth
 import com.adevspoon.domain.member.dto.request.MemberUpdateRequireDto
 import com.adevspoon.domain.member.dto.response.MemberAndSignup
@@ -123,7 +123,7 @@ class MemberDomainService(
         }
     }
 
-    fun getUserEntity(userId: Long): UserEntity {
+    private fun getUserEntity(userId: Long): UserEntity {
         return userRepository.findByIdOrNull(userId) ?: throw MemberNotFoundException()
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/AnswerEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/AnswerEntity.kt
@@ -1,8 +1,9 @@
 package com.adevspoon.domain.techQuestion.domain
 
 import com.adevspoon.domain.common.entity.LegacyBaseEntity
-import com.adevspoon.domain.techQuestion.domain.enums.AnswerStatus
 import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.techQuestion.domain.enums.AnswerStatus
+import com.adevspoon.domain.techQuestion.exception.NegativeLikeCountExceptionForTechQuestion
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.OnDelete
@@ -37,4 +38,15 @@ class AnswerEntity(
 
     @Column(name = "status", columnDefinition="ENUM('private','public')")
     var status: AnswerStatus = AnswerStatus.PUBLIC
-): LegacyBaseEntity()
+): LegacyBaseEntity() {
+    fun increaseLikeCount() {
+        this.likeCnt++
+    }
+
+    fun decreaseLikeCount() {
+        if (likeCnt - 1 < 0) {
+            throw NegativeLikeCountExceptionForTechQuestion("answer", id)
+        }
+        this.likeCnt--
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
@@ -14,6 +14,7 @@ enum class QuestionDomainErrorCode(
     QUESTION_EXHAUSTED(domain code 400 no 2, "발급 가능한 Question이 없습니다"),
     QUESTION_ANSWER_REPORT_NOT_ALLOWED(domain code 400 no 3, "해당 게시글은 신고할 수 없습니다"),
     QUESTION_ANSWER_REPORT_ALREADY_EXIST(domain code 400 no 4, "해당 게시글을 이미 신고했습니다"),
+    MINIMUM_LIKE_COUNT(domain code 400 no 5, "좋아요 수는 음수일 수 없습니다."),
 
     QUESTION_ANSWER_EDIT_UNAUTHORIZED(domain code 403 no 0, "해당 댓글에 수정 권한이 없습니다."),
 

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
@@ -14,3 +14,8 @@ class QuestionCategoryNotFoundException : AdevspoonException(QuestionDomainError
 class QuestionAnswerNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_ANSWER_NOT_FOUND)
 
 class QuestionAnswerInvalidReturnException : AdevspoonException(QuestionDomainErrorCode.QUESTION_ANSWER_INVALID_RETURN)
+
+class NegativeLikeCountExceptionForTechQuestion(type: String, contentId: Long) : AdevspoonException(
+    QuestionDomainErrorCode.MINIMUM_LIKE_COUNT,
+    detailReason = QuestionDomainErrorCode.MINIMUM_LIKE_COUNT.message + " type: $type, id: $contentId"
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
@@ -79,7 +79,7 @@ class AnswerDomainService(
 
     @Transactional
     fun toggleAnswerLike(answerId: Long, memberId: Long, isLiked: Boolean) {
-        likeDomainService.toggleLike(
+        likeDomainService.toggleAnswerLike(
             getAnswer(answerId),
             getMember(memberId),
             isLiked


### PR DESCRIPTION
### Issue
 
- close #59

### Summary
- 좋아요 기능하는 세 가지. answer, board, comment 별로 좋아요 기능을 만들었습니다.
- 좋아요 시 응답 내용을 통일화 했습니다.

### Description
- memberDomainService에서 entity가져오는 것을 각 도메인 서비스 내부에서 private으로 선언하여 가져오는 것으로 변경했습니다.