### PR TITLE
Feat#65. 게시글에 해당하는 댓글 가져오기 API

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardCommentController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardCommentController.kt
@@ -4,6 +4,7 @@ import com.adevspoon.api.board.dto.request.BoardCommentDeleteRequest
 import com.adevspoon.api.board.dto.request.RegisterBoardCommentRequest
 import com.adevspoon.api.board.dto.response.BoardCommentListResponse
 import com.adevspoon.api.board.dto.response.BoardCommentResponse
+import com.adevspoon.api.board.service.BoardCommentService
 import com.adevspoon.api.common.annotation.RequestUser
 import com.adevspoon.api.common.dto.RequestUserInfo
 import com.adevspoon.api.config.swagger.SWAGGER_TAG_BOARD_COMMENT
@@ -15,16 +16,16 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/board/comment")
 @Tag(name = SWAGGER_TAG_BOARD_COMMENT)
-class BoardCommentController {
+class BoardCommentController (
+    private val boardCommentService : BoardCommentService
+){
     @Operation(summary = "게시판 댓글 리스트 조회", description = "게시글 id를 쿼리로 받아 게시판 댓글 리스트 조회")
     @GetMapping
     fun getBoardCommentList(
         @RequestUser user: RequestUserInfo,
         @RequestParam postId: Long,
     ): BoardCommentListResponse {
-        TODO("""
-            게시판 댓글 리스트 조회
-        """.trimIndent())
+        return boardCommentService.getComments(postId, user.userId)
     }
 
     @Operation(summary = "게시글의 댓글 등록")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/response/BoardCommentListResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/response/BoardCommentListResponse.kt
@@ -1,5 +1,28 @@
 package com.adevspoon.api.board.dto.response
 
+import com.adevspoon.api.member.dto.response.MemberProfileResponse
+import com.adevspoon.domain.board.dto.response.BoardComment
+
 data class BoardCommentListResponse(
     val list: List<BoardCommentResponse>,
-)
+) {
+    companion object {
+        fun from(commentList: List<BoardComment>) : BoardCommentListResponse{
+            val commentResponseList = commentList.map { comment ->
+                BoardCommentResponse(
+                id = comment.id,
+                postId = comment.postId,
+                content = comment.content,
+                user = MemberProfileResponse.from(comment.user),
+                isLiked = comment.isLiked,
+                isMine = comment.isMine,
+                likeCount = comment.likeCount,
+                createdAt = comment.createdAt,
+                updatedAt = comment.updatedAt
+                )
+            }
+
+            return BoardCommentListResponse(commentResponseList)
+        }
+    }
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/response/BoardCommentListResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/response/BoardCommentListResponse.kt
@@ -7,18 +7,18 @@ data class BoardCommentListResponse(
     val list: List<BoardCommentResponse>,
 ) {
     companion object {
-        fun from(commentList: List<BoardComment>) : BoardCommentListResponse{
+        fun from(commentList: List<BoardComment>): BoardCommentListResponse {
             val commentResponseList = commentList.map { comment ->
                 BoardCommentResponse(
-                id = comment.id,
-                postId = comment.postId,
-                content = comment.content,
-                user = MemberProfileResponse.from(comment.user),
-                isLiked = comment.isLiked,
-                isMine = comment.isMine,
-                likeCount = comment.likeCount,
-                createdAt = comment.createdAt,
-                updatedAt = comment.updatedAt
+                    id = comment.id,
+                    postId = comment.postId,
+                    content = comment.content,
+                    user = MemberProfileResponse.from(comment.user),
+                    isLiked = comment.isLiked,
+                    isMine = comment.isMine,
+                    likeCount = comment.likeCount,
+                    createdAt = comment.createdAt,
+                    updatedAt = comment.updatedAt
                 )
             }
 

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardCommentService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardCommentService.kt
@@ -1,0 +1,16 @@
+package com.adevspoon.api.board.service
+
+import com.adevspoon.api.board.dto.response.BoardCommentListResponse
+import com.adevspoon.api.common.annotation.ApplicationService
+import com.adevspoon.domain.board.service.BoardCommentDomainService
+
+@ApplicationService
+class BoardCommentService (
+    private val boardCommentDomainService : BoardCommentDomainService
+){
+    fun getComments(postId: Long, userId: Long): BoardCommentListResponse {
+        val comments = boardCommentDomainService.getCommentsByPostId(postId, userId)
+        return BoardCommentListResponse.from(comments)
+    }
+
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/dto/response/BoardComment.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/dto/response/BoardComment.kt
@@ -1,0 +1,31 @@
+package com.adevspoon.domain.board.dto.response
+
+import com.adevspoon.domain.board.domain.BoardCommentEntity
+import com.adevspoon.domain.member.dto.response.MemberProfile
+import java.time.LocalDateTime
+
+data class BoardComment (
+    val id: Long,
+    val postId: Long,
+    val content: String,
+    val user: MemberProfile,
+    val isLiked: Boolean,
+    val isMine: Boolean?,
+    val likeCount: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun from(comment : BoardCommentEntity, memberProfile: MemberProfile, isLike: Boolean, isMine: Boolean?) = BoardComment(
+            id = comment.id,
+            postId = comment.post.id,
+            content = comment.content,
+            user = memberProfile,
+            isLiked = isLike,
+            isMine = isMine,
+            likeCount = comment.likeCount,
+            createdAt = comment.createdAt ?: LocalDateTime.now(),
+            updatedAt = comment.updatedAt ?: LocalDateTime.now()
+        )
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/dto/response/CommentAuthor.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/dto/response/CommentAuthor.kt
@@ -1,0 +1,9 @@
+package com.adevspoon.domain.board.dto.response
+
+import com.adevspoon.domain.board.domain.BoardCommentEntity
+import com.adevspoon.domain.member.domain.UserEntity
+
+data class CommentAuthor(
+    val user: UserEntity,
+    val comment: BoardCommentEntity
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardCommentRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardCommentRepository.kt
@@ -1,6 +1,12 @@
 package com.adevspoon.domain.board.repository
 
 import com.adevspoon.domain.board.domain.BoardCommentEntity
+import com.adevspoon.domain.board.domain.BoardPostEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
-interface BoardCommentRepository : JpaRepository<BoardCommentEntity, Long>
+interface BoardCommentRepository : JpaRepository<BoardCommentEntity, Long> {
+
+    @Query("SELECT c FROM BoardCommentEntity c WHERE c.post = :boardPost ORDER BY c.id DESC")
+    fun findAllByBoardPost(boardPost: BoardPostEntity) : List<BoardCommentEntity>
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardCommentRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardCommentRepository.kt
@@ -2,11 +2,13 @@ package com.adevspoon.domain.board.repository
 
 import com.adevspoon.domain.board.domain.BoardCommentEntity
 import com.adevspoon.domain.board.domain.BoardPostEntity
+import com.adevspoon.domain.board.dto.response.CommentAuthor
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
 interface BoardCommentRepository : JpaRepository<BoardCommentEntity, Long> {
 
-    @Query("SELECT c FROM BoardCommentEntity c WHERE c.post = :boardPost ORDER BY c.id DESC")
-    fun findAllByBoardPost(boardPost: BoardPostEntity) : List<BoardCommentEntity>
+    @Query("SELECT NEW com.adevspoon.domain.board.dto.response.CommentAuthor(c.user, c) FROM BoardCommentEntity c " +
+        "WHERE c.post = :post ORDER BY c.id DESC")
+    fun findCommentAuthorsByPost(post: BoardPostEntity): List<CommentAuthor>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
@@ -8,7 +8,6 @@ import com.adevspoon.domain.board.repository.BoardCommentRepository
 import com.adevspoon.domain.board.repository.BoardPostRepository
 import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.common.service.LikeDomainService
-import com.adevspoon.domain.member.repository.BadgeRepository
 import com.adevspoon.domain.member.service.MemberDomainService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
@@ -17,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional
 class BoardCommentDomainService(
     private val boardCommentRepository: BoardCommentRepository,
     private val boardPostRepository: BoardPostRepository,
-    private val badgeRepository: BadgeRepository,
     private val memberDomainService: MemberDomainService,
     private val likeDomainService: LikeDomainService
 ) {
@@ -27,11 +25,10 @@ class BoardCommentDomainService(
         val commentAndAuthors = boardCommentRepository.findCommentAuthorsByPost(boardPost)
         val commentIds = commentAndAuthors.map { it.comment.id }
         val likedCommentIds = getLikedCommentsByUser(userId, commentIds)
-        val badges = badgeRepository.findAll()
         return commentAndAuthors.map { commentAndAuthor ->
             BoardComment.from(
                 comment = commentAndAuthor.comment,
-                memberProfile = memberDomainService.getOtherMemberProfile(commentAndAuthor.user.id, badges),
+                memberProfile = memberDomainService.getOtherMemberProfile(commentAndAuthor.user.id),
                 isLike = likedCommentIds.contains(commentAndAuthor.comment.id),
                 isMine = commentAndAuthor.user.id == userId
             )

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
@@ -1,0 +1,46 @@
+package com.adevspoon.domain.board.service
+
+import com.adevspoon.domain.board.domain.BoardCommentEntity
+import com.adevspoon.domain.board.dto.response.BoardComment
+import com.adevspoon.domain.board.exception.BoardCommentNotFoundException
+import com.adevspoon.domain.board.exception.BoardPostNotFoundException
+import com.adevspoon.domain.board.repository.BoardCommentRepository
+import com.adevspoon.domain.board.repository.BoardPostRepository
+import com.adevspoon.domain.common.annotation.DomainService
+import com.adevspoon.domain.common.service.LikeDomainService
+import com.adevspoon.domain.member.service.MemberDomainService
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+
+@DomainService
+class BoardCommentDomainService(
+    private val boardCommentRepository: BoardCommentRepository,
+    private val boardPostRepository: BoardPostRepository,
+    private val memberDomainService: MemberDomainService,
+    private val likeDomainService: LikeDomainService
+) {
+    @Transactional(readOnly = true)
+    fun getCommentsByPostId(postId: Long, userId: Long): List<BoardComment> {
+        val boardPost = getBoardPostEntity(postId)
+        val comments = boardCommentRepository.findAllByBoardPost(boardPost)
+        val likedCommentIds = getLikedCommentsByUser(userId, comments.map { it.id }.toList())
+        return comments.map { comment ->
+            BoardComment.from(
+                comment = comment,
+                memberProfile = memberDomainService.getMemberProfile(comment.user.id),
+                isLike = likedCommentIds.contains(comment.id),
+                isMine = comment.user.id == userId
+            )
+        }
+    }
+
+    private fun getLikedCommentsByUser(loginUserId: Long, commentsIds: List<Long>): Set<Long> {
+        return likeDomainService.getLikedCommentIdsByUser(loginUserId, commentsIds).toSet()
+    }
+
+    private fun getBoardPostEntity(postId: Long) =
+        boardPostRepository.findByIdOrNull(postId) ?: throw BoardPostNotFoundException(postId.toString())
+
+    private fun getBoardCommentEntity(commentId: Long): BoardCommentEntity =
+        boardCommentRepository.findByIdOrNull(commentId) ?: throw BoardCommentNotFoundException(commentId.toString())
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
@@ -8,6 +8,7 @@ import com.adevspoon.domain.board.repository.BoardCommentRepository
 import com.adevspoon.domain.board.repository.BoardPostRepository
 import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.common.service.LikeDomainService
+import com.adevspoon.domain.member.repository.BadgeRepository
 import com.adevspoon.domain.member.service.MemberDomainService
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 class BoardCommentDomainService(
     private val boardCommentRepository: BoardCommentRepository,
     private val boardPostRepository: BoardPostRepository,
+    private val badgeRepository: BadgeRepository,
     private val memberDomainService: MemberDomainService,
     private val likeDomainService: LikeDomainService
 ) {
@@ -25,10 +27,11 @@ class BoardCommentDomainService(
         val commentAndAuthors = boardCommentRepository.findCommentAuthorsByPost(boardPost)
         val commentIds = commentAndAuthors.map { it.comment.id }
         val likedCommentIds = getLikedCommentsByUser(userId, commentIds)
+        val badges = badgeRepository.findAll()
         return commentAndAuthors.map { commentAndAuthor ->
             BoardComment.from(
                 comment = commentAndAuthor.comment,
-                memberProfile = memberDomainService.getOtherMemberProfile(commentAndAuthor.user.id),
+                memberProfile = memberDomainService.getOtherMemberProfile(commentAndAuthor.user.id, badges),
                 isLike = likedCommentIds.contains(commentAndAuthor.comment.id),
                 isMine = commentAndAuthor.user.id == userId
             )

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
@@ -22,14 +22,15 @@ class BoardCommentDomainService(
     @Transactional(readOnly = true)
     fun getCommentsByPostId(postId: Long, userId: Long): List<BoardComment> {
         val boardPost = getBoardPostEntity(postId)
-        val comments = boardCommentRepository.findAllByBoardPost(boardPost)
-        val likedCommentIds = getLikedCommentsByUser(userId, comments.map { it.id }.toList())
-        return comments.map { comment ->
+        val commentAndAuthors = boardCommentRepository.findCommentAuthorsByPost(boardPost)
+        val commentIds = commentAndAuthors.map { it.comment.id }
+        val likedCommentIds = getLikedCommentsByUser(userId, commentIds)
+        return commentAndAuthors.map { commentAndAuthor ->
             BoardComment.from(
-                comment = comment,
-                memberProfile = memberDomainService.getOtherMemberProfile(comment.user.id),
-                isLike = likedCommentIds.contains(comment.id),
-                isMine = comment.user.id == userId
+                comment = commentAndAuthor.comment,
+                memberProfile = memberDomainService.getOtherMemberProfile(commentAndAuthor.user.id),
+                isLike = likedCommentIds.contains(commentAndAuthor.comment.id),
+                isMine = commentAndAuthor.user.id == userId
             )
         }
     }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardCommentDomainService.kt
@@ -27,7 +27,7 @@ class BoardCommentDomainService(
         return comments.map { comment ->
             BoardComment.from(
                 comment = comment,
-                memberProfile = memberDomainService.getMemberProfile(comment.user.id),
+                memberProfile = memberDomainService.getOtherMemberProfile(comment.user.id),
                 isLike = likedCommentIds.contains(comment.id),
                 isMine = comment.user.id == userId
             )

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
@@ -74,7 +74,7 @@ class BoardPostDomainService(
 
     private fun buildBoardPostResponse(boardPost: BoardPostEntity, userId: Long): BoardPost {
         val isUserLikedBoardPost = likeDomainService.isUserLikedPost(userId, boardPost.id)
-        val memberProfile = memberDomainService.getMemberProfile(boardPost.user.id)
+        val memberProfile = memberDomainService.getOtherMemberProfile(boardPost.user.id)
 
         return BoardPost.from(boardPost, memberProfile, isUserLikedBoardPost)
     }
@@ -104,7 +104,7 @@ class BoardPostDomainService(
         val likedPostIds = getLikedPostsByUser(loginUserId, boardPosts.map { it.id }.toList()).toSet()
         val boardPostDto = boardPosts.map { boardPost ->
             val isUserLikedBoardPost = likedPostIds.contains(boardPost.id)
-            BoardPost.from(boardPost, memberDomainService.getMemberProfile(boardPost.user.id), isUserLikedBoardPost)
+            BoardPost.from(boardPost, memberDomainService.getOtherMemberProfile(boardPost.user.id), isUserLikedBoardPost)
         }
 
         return PageWithCursor(

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
@@ -21,6 +21,9 @@ interface LikeRepository : JpaRepository<LikeEntity, Long>, JpaSpecificationExec
     @Query("SELECT l.boardPostId FROM LikeEntity l WHERE l.user.id = :loginUserId AND l.boardPostId In :boardPostIds")
     fun findLikedPostIdsByUser(loginUserId: Long, boardPostIds: List<Long>): List<Long>
 
+    @Query("SELECT l.boardCommentId FROM LikeEntity l WHERE l.user.id = :loginUserId AND l.boardCommentId In :boardCommentIds")
+    fun findLikedCommentIdsByUser(loginUserId: Long, boardCommentIds: List<Long>): List<Long>
+
     @Modifying(clearAutomatically = true)
     fun deleteAllByUserAndAnswer(user: UserEntity, answer: AnswerEntity)
 

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/service/LikeDomainService.kt
@@ -28,6 +28,11 @@ class LikeDomainService(
         return likeRepository.findLikedPostIdsByUser(loginUserId, boardPostIds)
     }
 
+    @Transactional(readOnly = true)
+    fun getLikedCommentIdsByUser(loginUserId: Long, commentsIds: List<Long>): List<Long> {
+        return likeRepository.findLikedCommentIdsByUser(loginUserId, commentsIds)
+    }
+
     @Transactional
     fun toggleAnswerLike(answer: AnswerEntity, user: UserEntity, isLike: Boolean) {
         // FIXME : LikeEntity 나누기(Board, Comment, Answer), 각각 Unique Key 설정 필요 (현재 동시성을 못다룸 - 클라이언트에서만 처리)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
@@ -2,6 +2,7 @@ package com.adevspoon.domain.member.service
 
 import com.adevspoon.common.dto.OAuthUserInfo
 import com.adevspoon.domain.common.annotation.DomainService
+import com.adevspoon.domain.member.domain.BadgeEntity
 import com.adevspoon.domain.member.domain.UserActivityEntity
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.domain.enums.UserOAuth
@@ -69,6 +70,18 @@ class MemberDomainService(
             }
 
         return MemberProfile.from(user, null, userRepresentativeBadge)
+    }
+
+    @Transactional
+    fun getOtherMemberProfile(userId: Long, badgeList: List<BadgeEntity>): MemberProfile {
+        val user = getUserEntity(userId)
+        val userRepresentativeBadge = user.representativeBadge
+            ?.let {
+                badgeRepository.findByIdOrNull(user.representativeBadge)
+                    ?: throw MemberBadgeNotFoundException()
+            }
+
+        return MemberProfile.from(user, badgeList, userRepresentativeBadge)
     }
 
     @Transactional

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
@@ -2,7 +2,6 @@ package com.adevspoon.domain.member.service
 
 import com.adevspoon.common.dto.OAuthUserInfo
 import com.adevspoon.domain.common.annotation.DomainService
-import com.adevspoon.domain.member.domain.BadgeEntity
 import com.adevspoon.domain.member.domain.UserActivityEntity
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.domain.enums.UserOAuth
@@ -70,18 +69,6 @@ class MemberDomainService(
             }
 
         return MemberProfile.from(user, null, userRepresentativeBadge)
-    }
-
-    @Transactional
-    fun getOtherMemberProfile(userId: Long, badgeList: List<BadgeEntity>): MemberProfile {
-        val user = getUserEntity(userId)
-        val userRepresentativeBadge = user.representativeBadge
-            ?.let {
-                badgeRepository.findByIdOrNull(user.representativeBadge)
-                    ?: throw MemberBadgeNotFoundException()
-            }
-
-        return MemberProfile.from(user, badgeList, userRepresentativeBadge)
     }
 
     @Transactional


### PR DESCRIPTION
### Issue
 
- close #65 

### Summary
- 게시글에 해당하는 댓글 전부 가져오기

### Description
- 게시글이 존재하지 않는다면 예외처리.
- 유저가 해당 댓글에 좋아요 했는지 여부 가져올 때, N + 1 문제 방지.
- 댓글은 페이징처리 하지 않고 전체 가져오기.