### PR TITLE
Feat/#63. 발급받은 질문 리스트 가져오는 API(QueryDsl 추가)

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/controller/BoardController.kt
@@ -79,7 +79,7 @@ class BoardController(
         @RequestUser requestUser: RequestUserInfo,
         @RequestBody @Valid request: LikeBoardContentRequest
     ): String {
-        return boardService.toggleLike(request, requestUser.userId)
+        return boardService.likeBoard(request, requestUser.userId)
     }
 
     @Operation(summary = "게시글 신고")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/service/BoardService.kt
@@ -22,7 +22,7 @@ class BoardService(
         return BoardInfoResponse.from(boardPost)
     }
 
-    fun getBoardPostsByTags(request: BoardListRequest, loginUserId: Long) : BoardListResponse  {
+    fun getBoardPostsByTags(request: BoardListRequest, loginUserId: Long): BoardListResponse {
         val pageWithCursor = boardPostDomainService.getBoardPostsWithCriteria(request.toGetPostListRequestDto(), loginUserId)
         return BoardListResponse.from(pageWithCursor.data, pageWithCursor.nextCursorId)
     }
@@ -37,9 +37,13 @@ class BoardService(
         return "Successfully delete. postId:${request.postId}"
     }
 
-    fun toggleLike(request: LikeBoardContentRequest, userId: Long) : String{
-        boardPostDomainService.toggleLike(request.toLikeStateRequest(), userId)
-        return "Successfully toggle like"
+    fun likeBoard(request: LikeBoardContentRequest, userId: Long): String {
+        val likeRequest = request.toLikeStateRequest()
+        val type = likeRequest.type
+        val contentId = likeRequest.contentId
+
+        boardPostDomainService.toggleBoardLike(likeRequest, userId)
+        return if (likeRequest.like) "type:${type} contentId:${contentId} 좋아요 완료." else "type:${type} contentId:${contentId} 취소 완료."
     }
 
     fun report(request: ReportBoardContentRequest, userId: Long): String {

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionListController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionListController.kt
@@ -5,6 +5,7 @@ import com.adevspoon.api.common.dto.RequestUserInfo
 import com.adevspoon.api.config.swagger.SWAGGER_TAG_QUESTION
 import com.adevspoon.api.question.dto.request.QuestionListRequest
 import com.adevspoon.api.question.dto.response.QuestionListResponse
+import com.adevspoon.api.question.service.QuestionService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -16,19 +17,15 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/questionList")
 @Tag(name = SWAGGER_TAG_QUESTION)
-class QuestionListController {
+class QuestionListController(
+    private val questionService: QuestionService
+) {
     @Operation(summary = "발급받은 질문 리스트 조회")
     @GetMapping
     fun getQuestionList(
         @RequestUser user: RequestUserInfo,
         @Valid request: QuestionListRequest
     ): QuestionListResponse {
-
-        TODO("""
-            - 내가 발급받은 질문 리스트 조회
-            - 쿼리 Pageable한걸로 한 번더 매핑하기 - limit, offset, sort(newest, oldest), isAnswered
-            - isAnswered가 true면 answerId is not null인걸로
-            - 응답 - 질문 리스트, 다음 페이지 uri 
-        """.trimIndent())
+        return questionService.getQuestionList(user.userId, request)
     }
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionListController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionListController.kt
@@ -23,6 +23,7 @@ class QuestionListController {
         @RequestUser user: RequestUserInfo,
         @Valid request: QuestionListRequest
     ): QuestionListResponse {
+
         TODO("""
             - 내가 발급받은 질문 리스트 조회
             - 쿼리 Pageable한걸로 한 번더 매핑하기 - limit, offset, sort(newest, oldest), isAnswered

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionListRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionListRequest.kt
@@ -1,12 +1,31 @@
 package com.adevspoon.api.question.dto.request
 
+import com.adevspoon.domain.techQuestion.dto.request.GetIssuedQuestionList
 import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
 
 data class QuestionListRequest(
+    @Schema(description = "정렬. 기본값은 NEWEST(최신수)", nullable = true, defaultValue = "NEWEST")
     val sort: QuestionSortType = QuestionSortType.NEWEST,
-    @Schema(description = "등록한 답변만 가져올것인지 여부")
-    val isAnswered: Boolean = false,
+    @Schema(description = "등록한 답변만 가져올것인지 여부. (null일 경우 전부)", nullable = true)
+    val isAnswered: Boolean?,
+    @Schema(description = "필터링할 카테고리 리스트. (null일 경우 전부)", nullable = true)
+    val category: List<String> = emptyList(),
     val offset: Int = 0,
     val limit: Int = 10,
-)
+) {
+    fun toGetIssuedQuestionList(memberId: Long) = GetIssuedQuestionList(
+        memberId = memberId,
+        sort = sort.toIssuedQuestionSortType(),
+        isAnswered = isAnswered,
+        categoryNameList = category,
+        offset = offset,
+        limit = limit,
+    )
+
+    fun getNextUrl() = ServletUriComponentsBuilder.fromCurrentRequest()
+            .replaceQueryParam("offset", offset + limit)
+            .build()
+            .toUriString()
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionSortType.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionSortType.kt
@@ -1,9 +1,17 @@
 package com.adevspoon.api.question.dto.request
 
 import com.adevspoon.api.common.dto.LegacyDtoEnum
+import com.adevspoon.domain.techQuestion.dto.enums.IssuedQuestionSortType
 
 
 enum class QuestionSortType: LegacyDtoEnum {
     NEWEST,
-    OLDEST
+    OLDEST;
+
+    fun toIssuedQuestionSortType(): IssuedQuestionSortType {
+        return when (this) {
+            NEWEST -> IssuedQuestionSortType.NEWEST
+            OLDEST -> IssuedQuestionSortType.OLDEST
+        }
+    }
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/response/QuestionListResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/response/QuestionListResponse.kt
@@ -1,9 +1,19 @@
 package com.adevspoon.api.question.dto.response
 
+import com.adevspoon.domain.techQuestion.dto.response.IssuedQuestionListInfo
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class QuestionListResponse(
     val list: List<QuestionInfoResponse>,
     @Schema(description = "다음 페이지가 있는 경우 해당 URL을 사용하여 다음 페이지를 요청할 수 있습니다.", example = "https://api.adevspoon.com/api/postList?isAnswered=true&sort=newest&offset=10&limit=20", nullable = true)
-    val next: String,
-)
+    val next: String? = null,
+) {
+    companion object {
+        fun from(info: IssuedQuestionListInfo, nextUrl: String?): QuestionListResponse {
+            return QuestionListResponse(
+                list = info.list.map { QuestionInfoResponse.from(it) },
+                next = nextUrl,
+            )
+        }
+    }
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
@@ -1,16 +1,30 @@
 package com.adevspoon.api.question.service
 
 import com.adevspoon.api.common.annotation.ApplicationService
+import com.adevspoon.api.question.dto.request.QuestionListRequest
 import com.adevspoon.api.question.dto.response.QuestionCategoryResponse
 import com.adevspoon.api.question.dto.response.QuestionInfoResponse
+import com.adevspoon.api.question.dto.response.QuestionListResponse
 import com.adevspoon.domain.techQuestion.dto.request.GetTodayQuestion
 import com.adevspoon.domain.techQuestion.service.QuestionDomainService
+import com.adevspoon.domain.techQuestion.service.QuestionOpenDomainService
 import java.time.LocalDate
 
 @ApplicationService
 class QuestionService(
-    private val questionDomainService: QuestionDomainService
+    private val questionDomainService: QuestionDomainService,
+    private val questionOpenDomainService: QuestionOpenDomainService,
 ) {
+    fun getQuestionList(memberId: Long, request: QuestionListRequest): QuestionListResponse {
+        val issuedQuestionList = questionOpenDomainService.getIssuedQuestionList(
+            request.toGetIssuedQuestionList(memberId)
+        )
+        return QuestionListResponse.from(
+            issuedQuestionList,
+            if (issuedQuestionList.hasNext) request.getNextUrl() else null
+        )
+    }
+
     fun getTodayQuestion(memberId: Long): QuestionInfoResponse {
         return questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(memberId, LocalDate.now()))
             .let {

--- a/adevspoon-domain/build.gradle.kts
+++ b/adevspoon-domain/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 dependencies {
     implementation(project(":adevspoon-common"))
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    //querydsl
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
 
     runtimeOnly("com.mysql:mysql-connector-j")
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardCommentEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardCommentEntity.kt
@@ -1,5 +1,6 @@
 package com.adevspoon.domain.board.domain
 
+import com.adevspoon.domain.board.exception.NegativeLikeCountExceptionForBoard
 import com.adevspoon.domain.common.entity.BaseEntity
 import com.adevspoon.domain.member.domain.UserEntity
 import jakarta.persistence.*
@@ -33,4 +34,15 @@ class BoardCommentEntity(
     @NotNull
     @Column(name = "likeCount", nullable = false)
     var likeCount: Int = 0
-) : BaseEntity()
+) : BaseEntity() {
+    fun increaseLikeCount() {
+        this.likeCount++
+    }
+
+    fun decreaseLikeCount() {
+        if (likeCount - 1 < 0) {
+            throw NegativeLikeCountExceptionForBoard("board_comment", id)
+        }
+        this.likeCount--
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardPostEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/domain/BoardPostEntity.kt
@@ -1,5 +1,6 @@
 package com.adevspoon.domain.board.domain
 
+import com.adevspoon.domain.board.exception.NegativeLikeCountExceptionForBoard
 import com.adevspoon.domain.common.entity.BaseEntity
 import com.adevspoon.domain.member.domain.UserEntity
 import jakarta.persistence.*
@@ -49,6 +50,17 @@ class BoardPostEntity(
 ) : BaseEntity() {
     fun increaseViewCount() {
         this.viewCount++
+    }
+
+    fun increaseLikeCount() {
+        this.likeCount++
+    }
+
+    fun decreaseLikeCount() {
+        if (likeCount - 1 < 0) {
+            throw NegativeLikeCountExceptionForBoard("board_post", id)
+        }
+        this.likeCount--
     }
 
     fun updateTitleAndContent(title: String?, content: String?) {

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainErrorCode.kt
@@ -9,11 +9,16 @@ enum class PostDomainErrorCode(
     override val error: DomainType.Error,
     override val message: String,
 ): AdevspoonErrorCode {
+    MINIMUM_LIKE_COUNT(domain code 400 no 0, "좋아요 수는 음수일 수 없습니다."),
+
     BOARD_TAG_NOT_FOUND(domain code 404 no 0, "등록되지 않은 태그입니다."),
     BOARD_POST_NOT_FOUND(domain code 404 no 1, "등록되지 않은 게시글입니다."),
     BOARD_COMMENT_NOT_FOUND(domain code 404 no 2, "등록되지 않은 댓글입니다."),
+
     BOARD_POST_EDIT_UNAUTHORIZED(domain code 403 no 0, "해당 게시글에 권한이 없습니다."),
-    BOARD_POST_INVALID_RETURN(domain code 500 no 0, "게시글 등록 중 오류가 발생했습니다."),
     SELF_REPORT_NOT_ALLOWED(domain code 403 no 1, "자기 게시글 혹은 댓글은 신고할 수 없습니다."),
-    ALREADY_REPORTED(domain code  409 no 0, "이미 신고가 접수된 게시글 혹은 댓글입니다.");
+
+    ALREADY_REPORTED(domain code 409 no 0, "이미 신고가 접수된 게시글 혹은 댓글입니다."),
+
+    BOARD_POST_INVALID_RETURN(domain code 500 no 0, "게시글 등록 중 오류가 발생했습니다.");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/exception/PostDomainException.kt
@@ -23,3 +23,8 @@ class SelfReportException : AdevspoonException(SELF_REPORT_NOT_ALLOWED)
 class DuplicateReportException(type: String, contentId: Long) : AdevspoonException(
     ALREADY_REPORTED,
     detailReason = ALREADY_REPORTED.message + " 신고된 content type: $type, id: $contentId")
+
+class NegativeLikeCountExceptionForBoard(type: String, contentId: Long) : AdevspoonException(
+    MINIMUM_LIKE_COUNT,
+    detailReason = MINIMUM_LIKE_COUNT.message + " type: $type, id: $contentId"
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
@@ -14,16 +14,17 @@ interface LikeRepository : JpaRepository<LikeEntity, Long>, JpaSpecificationExec
 
     fun findByUserAndAnswer(user: UserEntity, answer: AnswerEntity): LikeEntity?
 
+    fun findByUserAndBoardPostId(user: UserEntity, boardPostId: Long): LikeEntity?
+
+    fun findByUserAndBoardCommentId(user: UserEntity, boardCommentId: Long): LikeEntity?
+
     @Query("SELECT l.boardPostId FROM LikeEntity l WHERE l.user.id = :loginUserId AND l.boardPostId In :boardPostIds")
     fun findLikedPostIdsByUser(loginUserId: Long, boardPostIds: List<Long>): List<Long>
 
-    @Query("SELECT  l FROM  LikeEntity l " +
-        "WHERE l.user.id = :userId " +
-        "AND ((:type = 'board_post' AND l.boardPostId = :contentId) " +
-        "OR (:type = 'board_comment' AND l.boardCommentId = :contentId))")
-    fun findByTypeAndUserId(type: String, userId: Long, contentId: Long): LikeEntity?
-
-
     @Modifying(clearAutomatically = true)
     fun deleteAllByUserAndAnswer(user: UserEntity, answer: AnswerEntity)
+
+    fun deleteAllByUserAndBoardPostId(user: UserEntity, boardPostId: Long)
+
+    fun deleteAllByUserAndBoardCommentId(user: UserEntity, boardCommentId: Long)
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/QueryDslConfig.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/QueryDslConfig.kt
@@ -1,0 +1,18 @@
+package com.adevspoon.domain.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig {
+    @PersistenceContext
+    lateinit var entityManager: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/UserEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/UserEntity.kt
@@ -77,4 +77,12 @@ class UserEntity(
     @NotNull
     @Column(name = "careerDescription", nullable = false)
     var careerDescription: String = ""
-): LegacyBaseEntity()
+): LegacyBaseEntity() {
+    fun increaseQuestionCnt() {
+        questionCnt += 1
+    }
+
+    fun increaseAnswerCnt() {
+        answerCnt += 1
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
@@ -2,8 +2,8 @@ package com.adevspoon.domain.member.service
 
 import com.adevspoon.common.dto.OAuthUserInfo
 import com.adevspoon.domain.common.annotation.DomainService
-import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.domain.UserActivityEntity
+import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.domain.enums.UserOAuth
 import com.adevspoon.domain.member.dto.request.MemberUpdateRequireDto
 import com.adevspoon.domain.member.dto.response.MemberAndSignup
@@ -123,7 +123,7 @@ class MemberDomainService(
         }
     }
 
-    fun getUserEntity(userId: Long): UserEntity {
+    private fun getUserEntity(userId: Long): UserEntity {
         return userRepository.findByIdOrNull(userId) ?: throw MemberNotFoundException()
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/AnswerEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/AnswerEntity.kt
@@ -1,8 +1,9 @@
 package com.adevspoon.domain.techQuestion.domain
 
 import com.adevspoon.domain.common.entity.LegacyBaseEntity
-import com.adevspoon.domain.techQuestion.domain.enums.AnswerStatus
 import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.techQuestion.domain.enums.AnswerStatus
+import com.adevspoon.domain.techQuestion.exception.NegativeLikeCountExceptionForTechQuestion
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.OnDelete
@@ -37,4 +38,15 @@ class AnswerEntity(
 
     @Column(name = "status", columnDefinition="ENUM('private','public')")
     var status: AnswerStatus = AnswerStatus.PUBLIC
-): LegacyBaseEntity()
+): LegacyBaseEntity() {
+    fun increaseLikeCount() {
+        this.likeCnt++
+    }
+
+    fun decreaseLikeCount() {
+        if (likeCnt - 1 < 0) {
+            throw NegativeLikeCountExceptionForTechQuestion("answer", id)
+        }
+        this.likeCnt--
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionOpenEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionOpenEntity.kt
@@ -38,4 +38,9 @@ class QuestionOpenEntity(
     @OnDelete(action = OnDeleteAction.SET_NULL)
     @JoinColumn(name = "answer_id")
     var answer: AnswerEntity? = null
-): BaseEntity()
+): BaseEntity() {
+    fun isAnswered(): Boolean = answer != null
+    fun setAnswer(answer: AnswerEntity) {
+        this.answer = answer
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionOpenEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionOpenEntity.kt
@@ -40,7 +40,7 @@ class QuestionOpenEntity(
     var answer: AnswerEntity? = null
 ): BaseEntity() {
     fun isAnswered(): Boolean = answer != null
-    fun setAnswer(answer: AnswerEntity) {
+    fun addAnswer(answer: AnswerEntity) {
         this.answer = answer
     }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/IssuedQuestionFilter.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/IssuedQuestionFilter.kt
@@ -1,0 +1,7 @@
+package com.adevspoon.domain.techQuestion.dto
+
+data class IssuedQuestionFilter(
+    val memberId: Long,
+    val categoryIds: List<Long>,
+    val isAnswered: Boolean?,
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/enums/IssuedQuestionSortType.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/enums/IssuedQuestionSortType.kt
@@ -1,0 +1,6 @@
+package com.adevspoon.domain.techQuestion.dto.enums
+
+enum class IssuedQuestionSortType {
+    NEWEST,
+    OLDEST
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/request/GetIssuedQuestionList.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/request/GetIssuedQuestionList.kt
@@ -1,0 +1,12 @@
+package com.adevspoon.domain.techQuestion.dto.request
+
+import com.adevspoon.domain.techQuestion.dto.enums.IssuedQuestionSortType
+
+data class GetIssuedQuestionList(
+    val memberId: Long,
+    val sort: IssuedQuestionSortType = IssuedQuestionSortType.NEWEST,
+    val isAnswered: Boolean?,
+    val categoryNameList: List<String> = emptyList(),
+    val offset: Int = 0,
+    val limit: Int = 10,
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/IssuedQuestionListInfo.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/IssuedQuestionListInfo.kt
@@ -1,0 +1,6 @@
+package com.adevspoon.domain.techQuestion.dto.response
+
+data class IssuedQuestionListInfo(
+    val list: List<QuestionInfo>,
+    val hasNext: Boolean,
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
@@ -14,6 +14,7 @@ enum class QuestionDomainErrorCode(
     QUESTION_EXHAUSTED(domain code 400 no 2, "발급 가능한 Question이 없습니다"),
     QUESTION_ANSWER_REPORT_NOT_ALLOWED(domain code 400 no 3, "해당 게시글은 신고할 수 없습니다"),
     QUESTION_ANSWER_REPORT_ALREADY_EXIST(domain code 400 no 4, "해당 게시글을 이미 신고했습니다"),
+    MINIMUM_LIKE_COUNT(domain code 400 no 5, "좋아요 수는 음수일 수 없습니다."),
 
     QUESTION_ANSWER_EDIT_UNAUTHORIZED(domain code 403 no 0, "해당 댓글에 수정 권한이 없습니다."),
 

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
@@ -14,3 +14,8 @@ class QuestionCategoryNotFoundException : AdevspoonException(QuestionDomainError
 class QuestionAnswerNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_ANSWER_NOT_FOUND)
 
 class QuestionAnswerInvalidReturnException : AdevspoonException(QuestionDomainErrorCode.QUESTION_ANSWER_INVALID_RETURN)
+
+class NegativeLikeCountExceptionForTechQuestion(type: String, contentId: Long) : AdevspoonException(
+    QuestionDomainErrorCode.MINIMUM_LIKE_COUNT,
+    detailReason = QuestionDomainErrorCode.MINIMUM_LIKE_COUNT.message + " type: $type, id: $contentId"
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionCategoryRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionCategoryRepository.kt
@@ -8,6 +8,9 @@ interface QuestionCategoryRepository: JpaRepository<QuestionCategoryEntity, Long
     @Query("SELECT qc from QuestionCategoryEntity qc where qc.id in :ids")
     fun findQuestionCategoryByIds(ids: List<Long>): List<QuestionCategoryEntity>
 
+    @Query("SELECT qc from QuestionCategoryEntity qc where qc.category in :names")
+    fun findByNames(names: List<String>): List<QuestionCategoryEntity>
+
     @Query("SELECT qc.id from QuestionCategoryEntity qc")
     fun findAllIds(): List<Long>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
@@ -7,7 +7,7 @@ import com.adevspoon.domain.techQuestion.dto.response.CategoryQuestionCountDto
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface QuestionOpenRepository: JpaRepository<QuestionOpenEntity, Long> {
+interface QuestionOpenRepository: JpaRepository<QuestionOpenEntity, Long>, QuestionOpenRepositoryCustom {
     @Query("SELECT qo " +
             "FROM QuestionOpenEntity qo " +
                 "LEFT JOIN FETCH qo.question " +

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepositoryCustom.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepositoryCustom.kt
@@ -1,0 +1,11 @@
+package com.adevspoon.domain.techQuestion.repository
+
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.dto.IssuedQuestionFilter
+import com.adevspoon.domain.techQuestion.dto.enums.IssuedQuestionSortType
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+interface QuestionOpenRepositoryCustom {
+    fun findQuestionOpenList(sort: IssuedQuestionSortType, filter: IssuedQuestionFilter, pageable: Pageable) : Slice<QuestionOpenEntity>
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepositoryCustomImpl.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepositoryCustomImpl.kt
@@ -1,0 +1,60 @@
+package com.adevspoon.domain.techQuestion.repository
+
+import com.adevspoon.domain.techQuestion.domain.QAnswerEntity.answerEntity
+import com.adevspoon.domain.techQuestion.domain.QQuestionEntity.questionEntity
+import com.adevspoon.domain.techQuestion.domain.QQuestionOpenEntity.questionOpenEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.dto.IssuedQuestionFilter
+import com.adevspoon.domain.techQuestion.dto.enums.IssuedQuestionSortType
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+
+class QuestionOpenRepositoryCustomImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+): QuestionOpenRepositoryCustom {
+    override fun findQuestionOpenList(
+        sort: IssuedQuestionSortType,
+        filter: IssuedQuestionFilter,
+        pageable: Pageable
+    ): Slice<QuestionOpenEntity> {
+        val resultList = jpaQueryFactory.selectFrom(questionOpenEntity)
+            .leftJoin(questionOpenEntity.question, questionEntity).fetchJoin()
+            .leftJoin(questionOpenEntity.answer, answerEntity).fetchJoin()
+            .where(
+                questionOpenEntity.user.id.eq(filter.memberId),
+                inCategory(filter.categoryIds),
+                isAnswered(filter.isAnswered),
+            )
+            .orderBy(sortOrder(sort))
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong() + 1)
+            .fetch()
+
+        var hasNext = false
+        if (resultList.size == pageable.pageSize + 1) {
+            hasNext = true
+            resultList.removeLast()
+        }
+
+        return SliceImpl(resultList, pageable, hasNext)
+    }
+
+    private fun inCategory(categoryIds: List<Long>) =
+        if (categoryIds.isEmpty()) null
+        else questionOpenEntity.question.categoryId.`in`(categoryIds)
+
+    private fun isAnswered(isAnswered: Boolean?) =
+        when (isAnswered) {
+            true -> questionOpenEntity.answer.isNotNull
+            false -> questionOpenEntity.answer.isNull
+            else -> null
+        }
+
+    private fun sortOrder(sort: IssuedQuestionSortType) =
+        when (sort) {
+            IssuedQuestionSortType.NEWEST -> questionOpenEntity.createdAt.desc()
+            IssuedQuestionSortType.OLDEST -> questionOpenEntity.createdAt.asc()
+        }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
@@ -42,7 +42,8 @@ class AnswerDomainService(
         val answer = AnswerEntity(question = question, answer = request.answer, user = requestMember)
 
         answerRepository.save(answer)
-        requestMember.apply { answerCnt += 1 }
+        issuedQuestion.setAnswer(answer)
+        requestMember.increaseAnswerCnt()
 
         return QuestionAnswerInfo.from(
             answer,

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
@@ -42,7 +42,7 @@ class AnswerDomainService(
         val answer = AnswerEntity(question = question, answer = request.answer, user = requestMember)
 
         answerRepository.save(answer)
-        issuedQuestion.setAnswer(answer)
+        issuedQuestion.addAnswer(answer)
         requestMember.increaseAnswerCnt()
 
         return QuestionAnswerInfo.from(

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
@@ -80,7 +80,7 @@ class AnswerDomainService(
 
     @Transactional
     fun toggleAnswerLike(answerId: Long, memberId: Long, isLiked: Boolean) {
-        likeDomainService.toggleLike(
+        likeDomainService.toggleAnswerLike(
             getAnswer(answerId),
             getMember(memberId),
             isLiked

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
@@ -30,7 +30,6 @@ class QuestionDomainService(
     private val userCustomizedQuestionCategoryRepository: UserCustomizedQuestionCategoryRepository,
     private val questionOpenDomainService: QuestionOpenDomainService,
 ) {
-
     @Transactional(readOnly = true)
     fun getQuestion(memberId: Long, questionId: Long): QuestionInfo {
         val user = getMember(memberId)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
@@ -4,8 +4,12 @@ import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.exception.MemberNotFoundException
 import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.dto.IssuedQuestionFilter
+import com.adevspoon.domain.techQuestion.dto.request.GetIssuedQuestionList
+import com.adevspoon.domain.techQuestion.dto.response.IssuedQuestionListInfo
 import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
 import com.adevspoon.domain.techQuestion.exception.QuestionCategoryNotFoundException
 import com.adevspoon.domain.techQuestion.exception.QuestionExhaustedException
@@ -15,6 +19,7 @@ import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
 import com.adevspoon.domain.techQuestion.repository.QuestionRepository
 import com.adevspoon.domain.techQuestion.repository.UserCustomizedQuestionCategoryRepository
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -29,6 +34,30 @@ class QuestionOpenDomainService(
     private val userCustomizedQuestionCategoryRepository: UserCustomizedQuestionCategoryRepository,
 ) {
     private val logger = LoggerFactory.getLogger(this.javaClass)!!
+
+    @Transactional
+    fun getIssuedQuestionList(request: GetIssuedQuestionList): IssuedQuestionListInfo {
+        val selectedCategoryList = getCategoryList(request.categoryNameList)
+        val targetCategoryIds = if (request.categoryNameList.isEmpty())
+            emptyList()
+        else
+            selectedCategoryList.map { it.id }
+
+        val issuedQuestionList = questionOpenRepository.findQuestionOpenList(
+            request.sort,
+            IssuedQuestionFilter(
+                request.memberId,
+                targetCategoryIds,
+                request.isAnswered
+            ),
+            PageRequest.of(request.offset / request.limit, request.limit)
+        )
+
+        return IssuedQuestionListInfo(
+            issuedQuestionList.content.map { makeQuestionInfo(it, selectedCategoryList) },
+            issuedQuestionList.hasNext()
+        )
+    }
 
     @Transactional(propagation = Propagation.MANDATORY)
     fun issueQuestion(memberId: Long, today: LocalDate): QuestionInfo {
@@ -55,12 +84,25 @@ class QuestionOpenDomainService(
         return makeQuestionInfo(issuedQuestion, candidateIssuableQuestionIds.size == 1)
     }
 
+    private fun getCategoryList(categoryNameList: List<String>): List<QuestionCategoryEntity> {
+        return if (categoryNameList.isNotEmpty())
+            questionCategoryRepository.findByNames(categoryNameList)
+        else
+            questionCategoryRepository.findAll()
+    }
+
     private fun getQuestion(questionId: Long): QuestionEntity {
         return questionRepository.findByIdOrNull(questionId) ?: throw QuestionNotFoundException()
     }
 
     private fun getMember(memberId: Long): UserEntity {
         return userRepository.findByIdOrNull(memberId) ?: throw MemberNotFoundException()
+    }
+
+    private fun makeQuestionInfo(questionOpen: QuestionOpenEntity, categoryList: List<QuestionCategoryEntity>): QuestionInfo {
+        val category = categoryList.find { it.id == questionOpen.question.categoryId }
+            ?: throw QuestionCategoryNotFoundException()
+        return QuestionInfo.from(questionOpen, category.category)
     }
 
     private fun makeQuestionInfo(questionOpen: QuestionOpenEntity, isLast: Boolean = false): QuestionInfo {

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
@@ -48,9 +48,9 @@ class QuestionOpenDomainService(
         val issuedQuestionId = candidateIssuableQuestionIds.random()
         val question = getQuestion(issuedQuestionId)
         val issuedQuestion = QuestionOpenEntity(user = user, question = question, openDate = today.atStartOfDay())
-        questionOpenRepository.save(issuedQuestion)
 
-        user.apply { questionCnt += 1 }
+        questionOpenRepository.save(issuedQuestion)
+        user.increaseQuestionCnt()
 
         return makeQuestionInfo(issuedQuestion, candidateIssuableQuestionIds.size == 1)
     }


### PR DESCRIPTION

### Issue 
- close #63

### Summary
- 발급받은 질문 리스트 가져오는 API 구현
- QueryDsl 의존성 추가

### Description
- 동적 쿼리(답변여부, 원하는 카테고리 설정, 정렬)가 들어가 QueryDsl 의존성도 추가하였습니다.