### PR TITLE
Feat/#70. 답변 리스트 가져오는 API

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/controller/AnswerListController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/controller/AnswerListController.kt
@@ -2,6 +2,7 @@ package com.adevspoon.api.answer.controller
 
 import com.adevspoon.api.answer.dto.request.AnswerListQueryRequest
 import com.adevspoon.api.answer.dto.response.AnswerListResponse
+import com.adevspoon.api.answer.service.AnswerService
 import com.adevspoon.api.common.annotation.RequestUser
 import com.adevspoon.api.common.dto.RequestUserInfo
 import com.adevspoon.api.config.swagger.SWAGGER_TAG_QUESTION_ANSWER
@@ -15,17 +16,15 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/postList")
 @Tag(name = SWAGGER_TAG_QUESTION_ANSWER)
-class AnswerListController {
-
+class AnswerListController(
+    private val answerService: AnswerService
+) {
     @Operation(summary = "특정 질문에 대한 답변 리스트", description = "질문 id에 해당하는 답변 리스트를 가져온다.")
     @GetMapping
     fun getAnswerList(
         @RequestUser user: RequestUserInfo,
         @Valid request: AnswerListQueryRequest
     ): AnswerListResponse {
-        TODO("""
-            - 답변 리스트를 가져온다.
-            - sort가 best인경우 현재유저가 받은 Today 질문의 Best 답변을 가져온다.
-        """.trimIndent())
+        return answerService.getAnswerList(request, user.userId)
     }
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/dto/request/AnswerListQueryRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/dto/request/AnswerListQueryRequest.kt
@@ -1,8 +1,10 @@
 package com.adevspoon.api.answer.dto.request
 
+import com.adevspoon.domain.techQuestion.dto.request.GetQuestionAnswerList
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.PositiveOrZero
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
 // TODO: Enum Validation 필요
 data class AnswerListQueryRequest(
@@ -19,4 +21,16 @@ data class AnswerListQueryRequest(
     @Schema(nullable = true, defaultValue = "10")
     @field:Positive(message = "limit은 양수여야 합니다.")
     val limit: Int = 10,
-)
+) {
+    fun toGetQuestionAnswerList(memberId: Long) = GetQuestionAnswerList(
+        memberId = memberId,
+        questionId = questionId,
+        sort = sort.toQuestionAnswerListSortType(),
+        offset = offset,
+        limit = limit
+    )
+    fun getNextUrl() = ServletUriComponentsBuilder.fromCurrentRequest()
+        .replaceQueryParam("offset", offset + limit)
+        .build()
+        .toUriString()
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/dto/request/AnswerSortType.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/dto/request/AnswerSortType.kt
@@ -1,10 +1,21 @@
 package com.adevspoon.api.answer.dto.request
 
 import com.adevspoon.api.common.dto.LegacyDtoEnum
+import com.adevspoon.domain.techQuestion.dto.enums.QuestionAnswerListSortType
 
 
 enum class AnswerSortType: LegacyDtoEnum {
     NEWEST,
     OLDEST,
     BEST,
+    LIKE;
+
+    fun toQuestionAnswerListSortType(): QuestionAnswerListSortType {
+        return when (this) {
+            NEWEST -> QuestionAnswerListSortType.NEWEST
+            OLDEST -> QuestionAnswerListSortType.OLDEST
+            BEST -> QuestionAnswerListSortType.BEST
+            LIKE -> QuestionAnswerListSortType.LIKE
+        }
+    }
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/dto/response/AnswerListResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/dto/response/AnswerListResponse.kt
@@ -3,7 +3,7 @@ package com.adevspoon.api.answer.dto.response
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class AnswerListResponse(
-    val list: AnswerInfoResponse,
+    val list: List<AnswerInfoResponse>,
     @Schema(description = "다음 페이지가 있는 경우 해당 URL을 사용하여 다음 페이지를 요청할 수 있습니다.", example = "https://api.adevspoon.com/api/postList?questionId=10&sort=newest&offset=10&limit=20", nullable = true)
     val next: String?
 )

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/service/AnswerService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/answer/service/AnswerService.kt
@@ -1,8 +1,11 @@
 package com.adevspoon.api.answer.service
 
+import com.adevspoon.api.answer.dto.request.AnswerListQueryRequest
+import com.adevspoon.api.answer.dto.request.AnswerSortType
 import com.adevspoon.api.answer.dto.request.AnswerUpdateRequest
 import com.adevspoon.api.answer.dto.request.RegisterAnswerRequest
 import com.adevspoon.api.answer.dto.response.AnswerInfoResponse
+import com.adevspoon.api.answer.dto.response.AnswerListResponse
 import com.adevspoon.api.common.annotation.ApplicationService
 import com.adevspoon.domain.techQuestion.dto.request.ModifyQuestionAnswer
 import com.adevspoon.domain.techQuestion.service.AnswerDomainService
@@ -21,6 +24,19 @@ class AnswerService(
             .from(
                 answerDomainService.getAnswerDetail(answerId, memberId)
             )
+    }
+
+    fun getAnswerList(request: AnswerListQueryRequest, memberId: Long): AnswerListResponse {
+        val answerList = if (request.sort == AnswerSortType.BEST) {
+            answerDomainService.getTodayBestAnswerList(memberId)
+        } else {
+            answerDomainService.getAnswerList(request.toGetQuestionAnswerList(memberId))
+        }
+
+        return AnswerListResponse(
+            answerList.list.map { AnswerInfoResponse.from(it) },
+            if (answerList.hasNext) request.getNextUrl() else null
+        )
     }
 
     fun modifyAnswer(answerId: Long, request: AnswerUpdateRequest, memberId: Long): AnswerInfoResponse {

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionListController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/controller/QuestionListController.kt
@@ -5,6 +5,7 @@ import com.adevspoon.api.common.dto.RequestUserInfo
 import com.adevspoon.api.config.swagger.SWAGGER_TAG_QUESTION
 import com.adevspoon.api.question.dto.request.QuestionListRequest
 import com.adevspoon.api.question.dto.response.QuestionListResponse
+import com.adevspoon.api.question.service.QuestionService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -16,18 +17,15 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/questionList")
 @Tag(name = SWAGGER_TAG_QUESTION)
-class QuestionListController {
+class QuestionListController(
+    private val questionService: QuestionService
+) {
     @Operation(summary = "발급받은 질문 리스트 조회")
     @GetMapping
     fun getQuestionList(
         @RequestUser user: RequestUserInfo,
         @Valid request: QuestionListRequest
     ): QuestionListResponse {
-        TODO("""
-            - 내가 발급받은 질문 리스트 조회
-            - 쿼리 Pageable한걸로 한 번더 매핑하기 - limit, offset, sort(newest, oldest), isAnswered
-            - isAnswered가 true면 answerId is not null인걸로
-            - 응답 - 질문 리스트, 다음 페이지 uri 
-        """.trimIndent())
+        return questionService.getQuestionList(user.userId, request)
     }
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionListRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionListRequest.kt
@@ -1,12 +1,31 @@
 package com.adevspoon.api.question.dto.request
 
+import com.adevspoon.domain.techQuestion.dto.request.GetIssuedQuestionList
 import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
 
 data class QuestionListRequest(
+    @Schema(description = "정렬. 기본값은 NEWEST(최신수)", nullable = true, defaultValue = "NEWEST")
     val sort: QuestionSortType = QuestionSortType.NEWEST,
-    @Schema(description = "등록한 답변만 가져올것인지 여부")
-    val isAnswered: Boolean = false,
+    @Schema(description = "등록한 답변만 가져올것인지 여부. (null일 경우 전부)", nullable = true)
+    val isAnswered: Boolean?,
+    @Schema(description = "필터링할 카테고리 리스트. (null일 경우 전부)", nullable = true)
+    val category: List<String> = emptyList(),
     val offset: Int = 0,
     val limit: Int = 10,
-)
+) {
+    fun toGetIssuedQuestionList(memberId: Long) = GetIssuedQuestionList(
+        memberId = memberId,
+        sort = sort.toIssuedQuestionSortType(),
+        isAnswered = isAnswered,
+        categoryNameList = category,
+        offset = offset,
+        limit = limit,
+    )
+
+    fun getNextUrl() = ServletUriComponentsBuilder.fromCurrentRequest()
+            .replaceQueryParam("offset", offset + limit)
+            .build()
+            .toUriString()
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionSortType.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/request/QuestionSortType.kt
@@ -1,9 +1,17 @@
 package com.adevspoon.api.question.dto.request
 
 import com.adevspoon.api.common.dto.LegacyDtoEnum
+import com.adevspoon.domain.techQuestion.dto.enums.IssuedQuestionSortType
 
 
 enum class QuestionSortType: LegacyDtoEnum {
     NEWEST,
-    OLDEST
+    OLDEST;
+
+    fun toIssuedQuestionSortType(): IssuedQuestionSortType {
+        return when (this) {
+            NEWEST -> IssuedQuestionSortType.NEWEST
+            OLDEST -> IssuedQuestionSortType.OLDEST
+        }
+    }
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/response/QuestionListResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/dto/response/QuestionListResponse.kt
@@ -1,9 +1,19 @@
 package com.adevspoon.api.question.dto.response
 
+import com.adevspoon.domain.techQuestion.dto.response.IssuedQuestionListInfo
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class QuestionListResponse(
     val list: List<QuestionInfoResponse>,
     @Schema(description = "다음 페이지가 있는 경우 해당 URL을 사용하여 다음 페이지를 요청할 수 있습니다.", example = "https://api.adevspoon.com/api/postList?isAnswered=true&sort=newest&offset=10&limit=20", nullable = true)
-    val next: String,
-)
+    val next: String? = null,
+) {
+    companion object {
+        fun from(info: IssuedQuestionListInfo, nextUrl: String?): QuestionListResponse {
+            return QuestionListResponse(
+                list = info.list.map { QuestionInfoResponse.from(it) },
+                next = nextUrl,
+            )
+        }
+    }
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/question/service/QuestionService.kt
@@ -1,16 +1,30 @@
 package com.adevspoon.api.question.service
 
 import com.adevspoon.api.common.annotation.ApplicationService
+import com.adevspoon.api.question.dto.request.QuestionListRequest
 import com.adevspoon.api.question.dto.response.QuestionCategoryResponse
 import com.adevspoon.api.question.dto.response.QuestionInfoResponse
+import com.adevspoon.api.question.dto.response.QuestionListResponse
 import com.adevspoon.domain.techQuestion.dto.request.GetTodayQuestion
 import com.adevspoon.domain.techQuestion.service.QuestionDomainService
+import com.adevspoon.domain.techQuestion.service.QuestionOpenDomainService
 import java.time.LocalDate
 
 @ApplicationService
 class QuestionService(
-    private val questionDomainService: QuestionDomainService
+    private val questionDomainService: QuestionDomainService,
+    private val questionOpenDomainService: QuestionOpenDomainService,
 ) {
+    fun getQuestionList(memberId: Long, request: QuestionListRequest): QuestionListResponse {
+        val issuedQuestionList = questionOpenDomainService.getIssuedQuestionList(
+            request.toGetIssuedQuestionList(memberId)
+        )
+        return QuestionListResponse.from(
+            issuedQuestionList,
+            if (issuedQuestionList.hasNext) request.getNextUrl() else null
+        )
+    }
+
     fun getTodayQuestion(memberId: Long): QuestionInfoResponse {
         return questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(memberId, LocalDate.now()))
             .let {

--- a/adevspoon-domain/build.gradle.kts
+++ b/adevspoon-domain/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
 dependencies {
     implementation(project(":adevspoon-common"))
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    //querydsl
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
 
     runtimeOnly("com.mysql:mysql-connector-j")
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/repository/LikeRepository.kt
@@ -21,6 +21,9 @@ interface LikeRepository : JpaRepository<LikeEntity, Long>, JpaSpecificationExec
     @Query("SELECT l.boardPostId FROM LikeEntity l WHERE l.user.id = :loginUserId AND l.boardPostId In :boardPostIds")
     fun findLikedPostIdsByUser(loginUserId: Long, boardPostIds: List<Long>): List<Long>
 
+    @Query("SELECT l.answer.id FROM LikeEntity l WHERE l.user.id = :userId AND l.answer.id In :answerIds")
+    fun findAllIdsByUserIdAndAnswerIds(userId: Long, answerIds: List<Long>): List<Long>
+
     @Modifying(clearAutomatically = true)
     fun deleteAllByUserAndAnswer(user: UserEntity, answer: AnswerEntity)
 

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/utils/LocalDateUtil.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/utils/LocalDateUtil.kt
@@ -1,0 +1,13 @@
+package com.adevspoon.domain.common.utils
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+
+fun LocalDate.isToday(): Boolean {
+    return this.compareTo(LocalDate.now()) == 0
+}
+
+fun LocalDateTime.isToday(): Boolean {
+    return this.toLocalDate().compareTo(LocalDate.now()) == 0
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/QueryDslConfig.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/config/QueryDslConfig.kt
@@ -1,0 +1,18 @@
+package com.adevspoon.domain.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig {
+    @PersistenceContext
+    lateinit var entityManager: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/BadgeEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/BadgeEntity.kt
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.Size
 class BadgeEntity(
     @Id
     @Column(name = "id", nullable = false)
-    val id: Int? = null,
+    val id: Int = 0,
 
     @Size(max = 50)
     @Column(name = "name", length = 50)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/UserEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/UserEntity.kt
@@ -77,4 +77,12 @@ class UserEntity(
     @NotNull
     @Column(name = "careerDescription", nullable = false)
     var careerDescription: String = ""
-): LegacyBaseEntity()
+): LegacyBaseEntity() {
+    fun increaseQuestionCnt() {
+        questionCnt += 1
+    }
+
+    fun increaseAnswerCnt() {
+        answerCnt += 1
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionOpenEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/domain/QuestionOpenEntity.kt
@@ -38,4 +38,9 @@ class QuestionOpenEntity(
     @OnDelete(action = OnDeleteAction.SET_NULL)
     @JoinColumn(name = "answer_id")
     var answer: AnswerEntity? = null
-): BaseEntity()
+): BaseEntity() {
+    fun isAnswered(): Boolean = answer != null
+    fun addAnswer(answer: AnswerEntity) {
+        this.answer = answer
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/IssuedQuestionFilter.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/IssuedQuestionFilter.kt
@@ -1,0 +1,7 @@
+package com.adevspoon.domain.techQuestion.dto
+
+data class IssuedQuestionFilter(
+    val memberId: Long,
+    val categoryIds: List<Long>,
+    val isAnswered: Boolean?,
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/enums/IssuedQuestionSortType.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/enums/IssuedQuestionSortType.kt
@@ -1,0 +1,6 @@
+package com.adevspoon.domain.techQuestion.dto.enums
+
+enum class IssuedQuestionSortType {
+    NEWEST,
+    OLDEST
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/enums/QuestionAnswerListSortType.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/enums/QuestionAnswerListSortType.kt
@@ -1,0 +1,8 @@
+package com.adevspoon.domain.techQuestion.dto.enums
+
+enum class QuestionAnswerListSortType{
+    NEWEST,
+    OLDEST,
+    BEST,
+    LIKE,
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/request/GetIssuedQuestionList.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/request/GetIssuedQuestionList.kt
@@ -1,0 +1,12 @@
+package com.adevspoon.domain.techQuestion.dto.request
+
+import com.adevspoon.domain.techQuestion.dto.enums.IssuedQuestionSortType
+
+data class GetIssuedQuestionList(
+    val memberId: Long,
+    val sort: IssuedQuestionSortType = IssuedQuestionSortType.NEWEST,
+    val isAnswered: Boolean?,
+    val categoryNameList: List<String> = emptyList(),
+    val offset: Int = 0,
+    val limit: Int = 10,
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/request/GetQuestionAnswerList.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/request/GetQuestionAnswerList.kt
@@ -1,0 +1,11 @@
+package com.adevspoon.domain.techQuestion.dto.request
+
+import com.adevspoon.domain.techQuestion.dto.enums.QuestionAnswerListSortType
+
+data class GetQuestionAnswerList(
+    val memberId: Long,
+    val questionId: Long?,
+    val sort: QuestionAnswerListSortType,
+    val offset: Int = 0,
+    val limit: Int = 10,
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/IssuedQuestionListInfo.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/IssuedQuestionListInfo.kt
@@ -1,0 +1,6 @@
+package com.adevspoon.domain.techQuestion.dto.response
+
+data class IssuedQuestionListInfo(
+    val list: List<QuestionInfo>,
+    val hasNext: Boolean,
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/QuestionAnswerListInfo.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/dto/response/QuestionAnswerListInfo.kt
@@ -1,0 +1,6 @@
+package com.adevspoon.domain.techQuestion.dto.response
+
+data class QuestionAnswerListInfo(
+    val list: List<QuestionAnswerInfo>,
+    val hasNext: Boolean,
+)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainErrorCode.kt
@@ -21,6 +21,7 @@ enum class QuestionDomainErrorCode(
     QUESTION_NOT_FOUND(domain code 404 no 0, "없는 Question ID로 조회 시도"),
     QUESTION_CATEGORY_NOT_FOUND(domain code 404 no 1, "없는 카테고리 ID로 등록 시도"),
     QUESTION_ANSWER_NOT_FOUND(domain code 404 no 2, "없는 Answer ID로 조회 시도"),
+    QUESTION_NOT_ISSUED(domain code 404 no 3, "아직 Question 이 발급되지 않았습니다"),
 
     QUESTION_ANSWER_INVALID_RETURN(domain code 500 no 0, "Answer 등록 중 오류가 발생했습니다");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/exception/QuestionDomainException.kt
@@ -2,6 +2,7 @@ package com.adevspoon.domain.techQuestion.exception
 
 import com.adevspoon.common.exception.AdevspoonException
 
+
 class QuestionNotOpenedException : AdevspoonException(QuestionDomainErrorCode.QUESTION_NOT_OPENED)
 class QuestionExhaustedException : AdevspoonException(QuestionDomainErrorCode.QUESTION_EXHAUSTED)
 class QuestionAnswerReportNotAllowedException : AdevspoonException(QuestionDomainErrorCode.QUESTION_ANSWER_REPORT_NOT_ALLOWED)
@@ -12,6 +13,7 @@ class QuestionAnswerEditUnauthorizedException : AdevspoonException(QuestionDomai
 class QuestionNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_NOT_FOUND)
 class QuestionCategoryNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_CATEGORY_NOT_FOUND)
 class QuestionAnswerNotFoundException : AdevspoonException(QuestionDomainErrorCode.QUESTION_ANSWER_NOT_FOUND)
+class QuestionNotIssuedException : AdevspoonException(QuestionDomainErrorCode.QUESTION_NOT_ISSUED)
 
 class QuestionAnswerInvalidReturnException : AdevspoonException(QuestionDomainErrorCode.QUESTION_ANSWER_INVALID_RETURN)
 

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/AnswerRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/AnswerRepository.kt
@@ -5,13 +5,20 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import java.sql.Date
 
-interface AnswerRepository: JpaRepository<AnswerEntity, Long> {
-
+interface AnswerRepository: JpaRepository<AnswerEntity, Long>, AnswerRepositoryCustom {
     @Query("SELECT a FROM AnswerEntity a " +
             "LEFT JOIN FETCH a.question " +
             "LEFT JOIN FETCH a.user " +
             "WHERE a.id = :answerId")
     fun findWithQuestionAndUser(answerId: Long): AnswerEntity?
+
+    @Query("SELECT a FROM AnswerEntity a " +
+                "LEFT JOIN FETCH a.question " +
+                "LEFT JOIN FETCH a.user " +
+            "WHERE a.question.id = :questionId " +
+            "ORDER BY a.likeCnt DESC " +
+            "LIMIT 1")
+    fun findBestAnswerListByQuestionId(questionId: Long): List<AnswerEntity>
 
     @Query("SELECT DATE(a.createdAt) " +
             "FROM AnswerEntity a " +

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/AnswerRepositoryCustom.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/AnswerRepositoryCustom.kt
@@ -1,0 +1,10 @@
+package com.adevspoon.domain.techQuestion.repository
+
+import com.adevspoon.domain.techQuestion.domain.AnswerEntity
+import com.adevspoon.domain.techQuestion.dto.enums.QuestionAnswerListSortType
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+interface AnswerRepositoryCustom {
+    fun findQuestionAnswerList(questionId: Long, sort: QuestionAnswerListSortType, pageable: Pageable): Slice<AnswerEntity>
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/AnswerRepositoryCustomImpl.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/AnswerRepositoryCustomImpl.kt
@@ -1,0 +1,44 @@
+package com.adevspoon.domain.techQuestion.repository
+
+import com.adevspoon.domain.techQuestion.domain.AnswerEntity
+import com.adevspoon.domain.techQuestion.domain.QAnswerEntity.answerEntity
+import com.adevspoon.domain.techQuestion.dto.enums.QuestionAnswerListSortType
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+
+class AnswerRepositoryCustomImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+): AnswerRepositoryCustom {
+    override fun findQuestionAnswerList(
+        questionId: Long,
+        sort: QuestionAnswerListSortType,
+        pageable: Pageable
+    ): Slice<AnswerEntity> {
+        val resultList = jpaQueryFactory.selectFrom(answerEntity)
+            .where(answerEntity.question.id.eq(questionId))
+            .join(answerEntity.user).fetchJoin()
+            .join(answerEntity.question).fetchJoin()
+            .orderBy(sortOrder(sort))
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong() + 1)
+            .fetch()
+
+        var hasNext = false
+        if (resultList.size == pageable.pageSize + 1) {
+            hasNext = true
+            resultList.removeLast()
+        }
+
+        return SliceImpl(resultList, pageable, hasNext)
+    }
+
+    private fun sortOrder(sort: QuestionAnswerListSortType) =
+        when (sort) {
+            QuestionAnswerListSortType.NEWEST -> answerEntity.createdAt.desc()
+            QuestionAnswerListSortType.OLDEST -> answerEntity.createdAt.asc()
+            QuestionAnswerListSortType.LIKE -> answerEntity.likeCnt.desc()
+            QuestionAnswerListSortType.BEST -> answerEntity.likeCnt.desc()
+        }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionCategoryRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionCategoryRepository.kt
@@ -8,6 +8,9 @@ interface QuestionCategoryRepository: JpaRepository<QuestionCategoryEntity, Long
     @Query("SELECT qc from QuestionCategoryEntity qc where qc.id in :ids")
     fun findQuestionCategoryByIds(ids: List<Long>): List<QuestionCategoryEntity>
 
+    @Query("SELECT qc from QuestionCategoryEntity qc where qc.category in :names")
+    fun findByNames(names: List<String>): List<QuestionCategoryEntity>
+
     @Query("SELECT qc.id from QuestionCategoryEntity qc")
     fun findAllIds(): List<Long>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
@@ -15,7 +15,7 @@ interface QuestionOpenRepository: JpaRepository<QuestionOpenEntity, Long>, Quest
             "WHERE qo.user = :user " +
             "ORDER BY qo.createdAt DESC " +
             "LIMIT 1")
-    fun findLatest(user: UserEntity): QuestionOpenEntity?
+    fun findLatestWithQuestionAndAnswer(user: UserEntity): QuestionOpenEntity?
 
     @Query("SELECT qo " +
             "FROM QuestionOpenEntity qo " +

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepository.kt
@@ -7,7 +7,7 @@ import com.adevspoon.domain.techQuestion.dto.response.CategoryQuestionCountDto
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface QuestionOpenRepository: JpaRepository<QuestionOpenEntity, Long> {
+interface QuestionOpenRepository: JpaRepository<QuestionOpenEntity, Long>, QuestionOpenRepositoryCustom {
     @Query("SELECT qo " +
             "FROM QuestionOpenEntity qo " +
                 "LEFT JOIN FETCH qo.question " +

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepositoryCustom.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepositoryCustom.kt
@@ -1,0 +1,11 @@
+package com.adevspoon.domain.techQuestion.repository
+
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.dto.IssuedQuestionFilter
+import com.adevspoon.domain.techQuestion.dto.enums.IssuedQuestionSortType
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+interface QuestionOpenRepositoryCustom {
+    fun findQuestionOpenList(sort: IssuedQuestionSortType, filter: IssuedQuestionFilter, pageable: Pageable) : Slice<QuestionOpenEntity>
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepositoryCustomImpl.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/repository/QuestionOpenRepositoryCustomImpl.kt
@@ -1,0 +1,60 @@
+package com.adevspoon.domain.techQuestion.repository
+
+import com.adevspoon.domain.techQuestion.domain.QAnswerEntity.answerEntity
+import com.adevspoon.domain.techQuestion.domain.QQuestionEntity.questionEntity
+import com.adevspoon.domain.techQuestion.domain.QQuestionOpenEntity.questionOpenEntity
+import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.dto.IssuedQuestionFilter
+import com.adevspoon.domain.techQuestion.dto.enums.IssuedQuestionSortType
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+
+class QuestionOpenRepositoryCustomImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+): QuestionOpenRepositoryCustom {
+    override fun findQuestionOpenList(
+        sort: IssuedQuestionSortType,
+        filter: IssuedQuestionFilter,
+        pageable: Pageable
+    ): Slice<QuestionOpenEntity> {
+        val resultList = jpaQueryFactory.selectFrom(questionOpenEntity)
+            .leftJoin(questionOpenEntity.question, questionEntity).fetchJoin()
+            .leftJoin(questionOpenEntity.answer, answerEntity).fetchJoin()
+            .where(
+                questionOpenEntity.user.id.eq(filter.memberId),
+                inCategory(filter.categoryIds),
+                isAnswered(filter.isAnswered),
+            )
+            .orderBy(sortOrder(sort))
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong() + 1)
+            .fetch()
+
+        var hasNext = false
+        if (resultList.size == pageable.pageSize + 1) {
+            hasNext = true
+            resultList.removeLast()
+        }
+
+        return SliceImpl(resultList, pageable, hasNext)
+    }
+
+    private fun inCategory(categoryIds: List<Long>) =
+        if (categoryIds.isEmpty()) null
+        else questionOpenEntity.question.categoryId.`in`(categoryIds)
+
+    private fun isAnswered(isAnswered: Boolean?) =
+        when (isAnswered) {
+            true -> questionOpenEntity.answer.isNotNull
+            false -> questionOpenEntity.answer.isNull
+            else -> null
+        }
+
+    private fun sortOrder(sort: IssuedQuestionSortType) =
+        when (sort) {
+            IssuedQuestionSortType.NEWEST -> questionOpenEntity.createdAt.desc()
+            IssuedQuestionSortType.OLDEST -> questionOpenEntity.createdAt.asc()
+        }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
@@ -42,7 +42,8 @@ class AnswerDomainService(
         val answer = AnswerEntity(question = question, answer = request.answer, user = requestMember)
 
         answerRepository.save(answer)
-        requestMember.apply { answerCnt += 1 }
+        issuedQuestion.addAnswer(answer)
+        requestMember.increaseAnswerCnt()
 
         return QuestionAnswerInfo.from(
             answer,

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
@@ -26,9 +26,9 @@ import com.adevspoon.domain.techQuestion.exception.*
 import com.adevspoon.domain.techQuestion.repository.AnswerRepository
 import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
 import com.adevspoon.domain.techQuestion.repository.QuestionRepository
-import jakarta.transaction.Transactional
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 
 @DomainService
@@ -63,7 +63,7 @@ class AnswerDomainService(
         )
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     fun getAnswerDetail(answerId: Long, requestMemberId: Long): QuestionAnswerInfo {
         val requestMember = getMember(requestMemberId)
         val answer = getAnswerWithUserAndQuestion(answerId)
@@ -78,7 +78,7 @@ class AnswerDomainService(
         )
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     fun getTodayBestAnswerList(memberId: Long): QuestionAnswerListInfo {
         val member = getMember(memberId)
         val latestIssuedQuestion = getLatestIssuedQuestion(member)
@@ -92,7 +92,7 @@ class AnswerDomainService(
         return makeQuestionAnswerListInfo(memberId, answerList, false)
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     fun getAnswerList(request: GetQuestionAnswerList): QuestionAnswerListInfo {
         if (request.questionId == null) throw QuestionNotFoundException()
 

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/AnswerDomainService.kt
@@ -4,24 +4,32 @@ import com.adevspoon.domain.common.annotation.ActivityEvent
 import com.adevspoon.domain.common.annotation.ActivityEventType
 import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.common.entity.ReportEntity
+import com.adevspoon.domain.common.repository.LikeRepository
 import com.adevspoon.domain.common.repository.ReportRepository
 import com.adevspoon.domain.common.service.LikeDomainService
+import com.adevspoon.domain.common.utils.isToday
 import com.adevspoon.domain.member.domain.UserEntity
+import com.adevspoon.domain.member.dto.response.MemberProfile
 import com.adevspoon.domain.member.exception.MemberNotFoundException
+import com.adevspoon.domain.member.repository.BadgeRepository
 import com.adevspoon.domain.member.repository.UserRepository
 import com.adevspoon.domain.member.service.MemberDomainService
 import com.adevspoon.domain.techQuestion.domain.AnswerEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
 import com.adevspoon.domain.techQuestion.dto.request.CreateQuestionAnswer
+import com.adevspoon.domain.techQuestion.dto.request.GetQuestionAnswerList
 import com.adevspoon.domain.techQuestion.dto.request.ModifyQuestionAnswer
 import com.adevspoon.domain.techQuestion.dto.response.QuestionAnswerInfo
+import com.adevspoon.domain.techQuestion.dto.response.QuestionAnswerListInfo
 import com.adevspoon.domain.techQuestion.exception.*
 import com.adevspoon.domain.techQuestion.repository.AnswerRepository
 import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
 import com.adevspoon.domain.techQuestion.repository.QuestionRepository
 import jakarta.transaction.Transactional
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
 
 @DomainService
 class AnswerDomainService(
@@ -29,7 +37,9 @@ class AnswerDomainService(
     private val questionOpenRepository: QuestionOpenRepository,
     private val answerRepository: AnswerRepository,
     private val userRepository: UserRepository,
+    private val badgeRepository: BadgeRepository,
     private val reportRepository: ReportRepository,
+    private val likeRepository: LikeRepository,
     private val memberDomainService: MemberDomainService,
     private val likeDomainService: LikeDomainService
 ) {
@@ -69,6 +79,33 @@ class AnswerDomainService(
     }
 
     @Transactional
+    fun getTodayBestAnswerList(memberId: Long): QuestionAnswerListInfo {
+        val member = getMember(memberId)
+        val latestIssuedQuestion = getLatestIssuedQuestion(member)
+
+        if (!latestIssuedQuestion.openDate.isToday()) throw QuestionNotIssuedException()
+
+        val answerList = answerRepository.findBestAnswerListByQuestionId(latestIssuedQuestion.question.id)
+            .takeIf { it.isNotEmpty() }
+            ?: throw QuestionAnswerNotFoundException()
+
+        return makeQuestionAnswerListInfo(memberId, answerList, false)
+    }
+
+    @Transactional
+    fun getAnswerList(request: GetQuestionAnswerList): QuestionAnswerListInfo {
+        if (request.questionId == null) throw QuestionNotFoundException()
+
+        val answerList = answerRepository.findQuestionAnswerList(
+            request.questionId,
+            request.sort,
+            PageRequest.of(request.offset / request.limit, request.limit)
+        )
+
+        return makeQuestionAnswerListInfo(request.memberId, answerList.content, answerList.hasNext())
+    }
+
+    @Transactional
     fun modifyAnswerInfo(request: ModifyQuestionAnswer): QuestionAnswerInfo {
         getAnswerWithUserAndQuestion(request.answerId)
             .takeIf { it.user.id == request.memberId }
@@ -98,10 +135,38 @@ class AnswerDomainService(
         reportRepository.save(ReportEntity(user = member, postType = "answer", post = answer))
     }
 
+    private fun makeQuestionAnswerListInfo(
+        requestMemberId: Long,
+        answerList: List<AnswerEntity>,
+        hasNext: Boolean
+    ): QuestionAnswerListInfo {
+        val badgeList = badgeRepository.findAll()
+        val likedAnswerIdsList = likeRepository.findAllIdsByUserIdAndAnswerIds(requestMemberId, answerList.map { it.id })
+
+        return QuestionAnswerListInfo(
+            answerList.map {
+                QuestionAnswerInfo.from(
+                    it,
+                    MemberProfile.from(
+                        it.user,
+                        null,
+                        badgeList.find { badge -> badge.id == it.user.representativeBadge }),
+                    LocalDate.now(), // 무의미한 값
+                    likedAnswerIdsList.contains(it.id)
+                )
+            },
+            hasNext
+        )
+    }
+
     private fun checkReport(member: UserEntity, answer: AnswerEntity) {
         reportRepository.findAllByUserAndPost(member, answer)
             .takeIf { it.isEmpty() }
             ?: throw QuestionAnswerReportAlreadyExistException()
+    }
+
+    private fun getLatestIssuedQuestion(member: UserEntity): QuestionOpenEntity {
+        return questionOpenRepository.findLatestWithQuestionAndAnswer(member) ?: throw QuestionNotOpenedException()
     }
 
     private fun getAnswerWithUserAndQuestion(answerId: Long): AnswerEntity {

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
@@ -30,7 +30,6 @@ class QuestionDomainService(
     private val userCustomizedQuestionCategoryRepository: UserCustomizedQuestionCategoryRepository,
     private val questionOpenDomainService: QuestionOpenDomainService,
 ) {
-
     @Transactional(readOnly = true)
     fun getQuestion(memberId: Long, questionId: Long): QuestionInfo {
         val user = getMember(memberId)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainService.kt
@@ -2,6 +2,7 @@ package com.adevspoon.domain.techQuestion.service
 
 import com.adevspoon.domain.common.annotation.DistributedLock
 import com.adevspoon.domain.common.annotation.DomainService
+import com.adevspoon.domain.common.utils.isToday
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.exception.MemberNotFoundException
 import com.adevspoon.domain.member.repository.UserRepository
@@ -43,9 +44,8 @@ class QuestionDomainService(
     @DistributedLock(keyClass = [GetTodayQuestion::class])
     fun getOrCreateTodayQuestion(request: GetTodayQuestion): QuestionInfo {
         val user = getMember(request.memberId)
-        val latestIssuedQuestion = questionOpenRepository.findLatest(user)
-
-        val isTodayQuestion = (latestIssuedQuestion?.openDate?.toLocalDate()?.compareTo(request.today) ?: -1) == 0
+        val latestIssuedQuestion = questionOpenRepository.findLatestWithQuestionAndAnswer(user)
+        val isTodayQuestion = latestIssuedQuestion?.openDate?.isToday() ?: false
 
         return if(isTodayQuestion) makeQuestionInfo(latestIssuedQuestion!!)
         else questionOpenDomainService.issueQuestion(request.memberId, request.today)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/techQuestion/service/QuestionOpenDomainService.kt
@@ -4,8 +4,12 @@ import com.adevspoon.domain.common.annotation.DomainService
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.exception.MemberNotFoundException
 import com.adevspoon.domain.member.repository.UserRepository
+import com.adevspoon.domain.techQuestion.domain.QuestionCategoryEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionEntity
 import com.adevspoon.domain.techQuestion.domain.QuestionOpenEntity
+import com.adevspoon.domain.techQuestion.dto.IssuedQuestionFilter
+import com.adevspoon.domain.techQuestion.dto.request.GetIssuedQuestionList
+import com.adevspoon.domain.techQuestion.dto.response.IssuedQuestionListInfo
 import com.adevspoon.domain.techQuestion.dto.response.QuestionInfo
 import com.adevspoon.domain.techQuestion.exception.QuestionCategoryNotFoundException
 import com.adevspoon.domain.techQuestion.exception.QuestionExhaustedException
@@ -15,6 +19,7 @@ import com.adevspoon.domain.techQuestion.repository.QuestionOpenRepository
 import com.adevspoon.domain.techQuestion.repository.QuestionRepository
 import com.adevspoon.domain.techQuestion.repository.UserCustomizedQuestionCategoryRepository
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -29,6 +34,30 @@ class QuestionOpenDomainService(
     private val userCustomizedQuestionCategoryRepository: UserCustomizedQuestionCategoryRepository,
 ) {
     private val logger = LoggerFactory.getLogger(this.javaClass)!!
+
+    @Transactional
+    fun getIssuedQuestionList(request: GetIssuedQuestionList): IssuedQuestionListInfo {
+        val selectedCategoryList = getCategoryList(request.categoryNameList)
+        val targetCategoryIds = if (request.categoryNameList.isEmpty())
+            emptyList()
+        else
+            selectedCategoryList.map { it.id }
+
+        val issuedQuestionList = questionOpenRepository.findQuestionOpenList(
+            request.sort,
+            IssuedQuestionFilter(
+                request.memberId,
+                targetCategoryIds,
+                request.isAnswered
+            ),
+            PageRequest.of(request.offset / request.limit, request.limit)
+        )
+
+        return IssuedQuestionListInfo(
+            issuedQuestionList.content.map { makeQuestionInfo(it, selectedCategoryList) },
+            issuedQuestionList.hasNext()
+        )
+    }
 
     @Transactional(propagation = Propagation.MANDATORY)
     fun issueQuestion(memberId: Long, today: LocalDate): QuestionInfo {
@@ -48,11 +77,18 @@ class QuestionOpenDomainService(
         val issuedQuestionId = candidateIssuableQuestionIds.random()
         val question = getQuestion(issuedQuestionId)
         val issuedQuestion = QuestionOpenEntity(user = user, question = question, openDate = today.atStartOfDay())
-        questionOpenRepository.save(issuedQuestion)
 
-        user.apply { questionCnt += 1 }
+        questionOpenRepository.save(issuedQuestion)
+        user.increaseQuestionCnt()
 
         return makeQuestionInfo(issuedQuestion, candidateIssuableQuestionIds.size == 1)
+    }
+
+    private fun getCategoryList(categoryNameList: List<String>): List<QuestionCategoryEntity> {
+        return if (categoryNameList.isNotEmpty())
+            questionCategoryRepository.findByNames(categoryNameList)
+        else
+            questionCategoryRepository.findAll()
     }
 
     private fun getQuestion(questionId: Long): QuestionEntity {
@@ -61,6 +97,12 @@ class QuestionOpenDomainService(
 
     private fun getMember(memberId: Long): UserEntity {
         return userRepository.findByIdOrNull(memberId) ?: throw MemberNotFoundException()
+    }
+
+    private fun makeQuestionInfo(questionOpen: QuestionOpenEntity, categoryList: List<QuestionCategoryEntity>): QuestionInfo {
+        val category = categoryList.find { it.id == questionOpen.question.categoryId }
+            ?: throw QuestionCategoryNotFoundException()
+        return QuestionInfo.from(questionOpen, category.category)
     }
 
     private fun makeQuestionInfo(questionOpen: QuestionOpenEntity, isLast: Boolean = false): QuestionInfo {

--- a/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceUnitTest.kt
+++ b/adevspoon-domain/src/test/kotlin/com/adevspoon/domain/techQuestion/service/QuestionDomainServiceUnitTest.kt
@@ -122,14 +122,14 @@ class QuestionDomainServiceUnitTest {
                     openDate = LocalDateTime.now().minusDays(1)
                 )
             val newIssuedQuestionInfo = QuestionFixture.createQuestionInfo(questionId = question2.id)
-            every { questionOpenRepository.findLatest(user) } returns latestIssuedQuestion
+            every { questionOpenRepository.findLatestWithQuestionAndAnswer(user) } returns latestIssuedQuestion
             every { questionOpenDomainService.issueQuestion(user.id, today) } returns newIssuedQuestionInfo
 
             val questionInfo = questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(user.id, today))
 
             assertEquals(questionInfo.questionId, question2.id)
 
-            verify { questionOpenRepository.findLatest(user) }
+            verify { questionOpenRepository.findLatestWithQuestionAndAnswer(user) }
             verify { questionOpenDomainService.issueQuestion(any(), any()) }
         }
 
@@ -138,14 +138,14 @@ class QuestionDomainServiceUnitTest {
             val latestIssuedQuestion =
                 QuestionFixture.createQuestionOpen(1, question1, user = user, openDate = LocalDateTime.now())
             val newIssuedQuestionInfo = QuestionFixture.createQuestionInfo(questionId = question2.id)
-            every { questionOpenRepository.findLatest(user) } returns latestIssuedQuestion
+            every { questionOpenRepository.findLatestWithQuestionAndAnswer(user) } returns latestIssuedQuestion
             every { questionOpenDomainService.issueQuestion(any(), any()) } returns newIssuedQuestionInfo
 
             val questionInfo = questionDomainService.getOrCreateTodayQuestion(GetTodayQuestion(1, LocalDate.now()))
 
             assertEquals(questionInfo.questionId, question1.id)
 
-            verify { questionOpenRepository.findLatest(user) }
+            verify { questionOpenRepository.findLatestWithQuestionAndAnswer(user) }
             verify(exactly = 0) { questionOpenDomainService.issueQuestion(any(), any()) }
         }
     }


### PR DESCRIPTION

### Issue 
- close #70

### Summary
- 답변 리스트 가져오는 API 구현

### Description
- 쿼리에 따라 오늘의 질문에 대한 베스트 답변 리스트, 특정 질문에 대한 답변 리스트로 나누어서 처리했습니다.
- 답변 리스트에는 답변 유저의 정보(어떤 뱃지를 가지고 있는지), 내가 좋아요 했는지 에 대한 정보도 들어갑니다. 이를 효율적으로 처리하기 위해(N+1을 피하기 위해) 3번의 쿼리로 나누어서 처리했습니다
    - answer List 가져오기(유저정보 join)
    - 유저 Badge List 가져오기
    - answer Ids 로 내가 좋아요한 List 가져오기
    - 앱내에서 위 3개를 매핑시켜 응답용 AnswerList 만들기