### PR TITLE
Feat/#83. 토큰 재발급, 유저 정보, 출석, 회원탈퇴, 뱃지리스트 API

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/auth/controller/AuthController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/auth/controller/AuthController.kt
@@ -2,6 +2,7 @@ package com.adevspoon.api.auth.controller
 
 import com.adevspoon.api.auth.dto.request.RefreshTokenRequest
 import com.adevspoon.api.auth.dto.response.TokenResponse
+import com.adevspoon.api.auth.service.AuthService
 import com.adevspoon.api.common.annotation.RequestUser
 import com.adevspoon.api.common.annotation.SecurityIgnored
 import com.adevspoon.api.common.dto.RequestUserInfo
@@ -16,7 +17,9 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @Tag(name = SWAGGER_TAG_ACCOUNT)
-class AuthController {
+class AuthController(
+    private val authService: AuthService
+) {
 
     @Operation(summary = "토큰 재발급", description = "access/refresh 토큰 재발급")
     @PostMapping("/refresh")
@@ -24,13 +27,10 @@ class AuthController {
     fun refreshToken(
         @RequestBody @Valid request: RefreshTokenRequest,
     ): TokenResponse {
-        TODO("""
-            - 토큰 재발급
-            - refreshToken 만료시간 체크 및 user에 업데이트
-        """.trimIndent())
+        return authService.refreshToken(request)
     }
 
-    @Operation(summary = "로그아웃", description = "로그인 상태에서 로그아웃 처리")
+    @Operation(summary = "(웹) 로그아웃", description = "로그인 상태에서 로그아웃 처리")
     @PostMapping("/logout")
     fun logout(
         @RequestUser user: RequestUserInfo

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/auth/service/AuthService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/auth/service/AuthService.kt
@@ -27,6 +27,11 @@ class AuthService(
         return MemberAndTokenResponse.from(memberAndSignup, tokenResponse)
     }
 
+    fun withdraw(userId: Long): String {
+        memberDomainService.withdraw(userId)
+        return "회원탈퇴 완료되었습니다"
+    }
+
     fun refreshToken(request: RefreshTokenRequest): TokenResponse {
         jwtProcessor.checkOwnToken(request.accessToken)
         val oldTokenInfo = jwtProcessor.validateServiceToken(request.refreshToken)

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/common/util/JwtProcessor.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/common/util/JwtProcessor.kt
@@ -5,11 +5,9 @@ import com.adevspoon.api.common.dto.JwtTokenType
 import com.adevspoon.api.common.enums.ServiceRole
 import com.adevspoon.api.common.properties.JwtProperties
 import com.adevspoon.common.exception.common.CommonUnauthorizedException
-import com.fasterxml.jackson.databind.ObjectMapper
 import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
-import org.apache.tomcat.util.codec.binary.Base64
 import org.springframework.stereotype.Component
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -24,7 +22,6 @@ private const val USER_TOKEN_TYPE = "tokenType"
 @Component
 class JwtProcessor(
     private val jwtProperties: JwtProperties,
-    private val objectMapper: ObjectMapper,
 ) {
     fun createToken(jwtTokenInfo: JwtTokenInfo): String = Jwts.builder()
         .claim(USER_ID, jwtTokenInfo.userId)
@@ -77,13 +74,5 @@ class JwtProcessor(
         } catch (e: Exception) {
             throw CommonUnauthorizedException()
         }
-    }
-
-    fun extractUserId(token: String): Long = try {
-        val encodedBody = token.split("\\.".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()[1]
-        val decodedBytes = Base64.decodeBase64(encodedBody)
-        objectMapper.readValue(decodedBytes, JwtTokenInfo::class.java).userId
-    } catch (e: Exception) {
-        throw CommonUnauthorizedException()
     }
 }

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/config/security/JwtTokenAuthenticationFilter.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/config/security/JwtTokenAuthenticationFilter.kt
@@ -24,7 +24,7 @@ class JwtTokenAuthenticationFilter(
             return
         }
 
-        val tokenInfo = jwtProcessor.validateAuthorizationHeader(authHeader)
+        val tokenInfo = jwtProcessor.validateServiceToken(authHeader)
         SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(
             RequestUserInfo(tokenInfo.userId),
             null,

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/controller/MemberController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/controller/MemberController.kt
@@ -62,9 +62,7 @@ class MemberController(
     @Operation(summary = "출석", description = "앱 내 출석체크")
     @GetMapping("/attendance")
     fun attendance(@RequestUser requestUser: RequestUserInfo): MemberProfileResponse {
-        TODO("""
-            - 출석 체크
-        """.trimIndent())
+        return memberService.attend(requestUser.userId)
     }
 
     @Operation(summary = "획득한 뱃지 리스트 가져오기", description = "호출자가 얻은 뱃지 리스트 가져오기")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/controller/MemberController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/controller/MemberController.kt
@@ -62,14 +62,11 @@ class MemberController(
         return memberService.attend(requestUser.userId)
     }
 
-    @Operation(summary = "획득한 뱃지 리스트 가져오기", description = "호출자가 얻은 뱃지 리스트 가져오기")
+    @Operation(summary = "뱃지 리스트 가져오기", description = "획득 여부, 달성률이 포함되어 있음")
     @GetMapping("/badge")
-    fun getAchievedBadge(@RequestUser requestUser: RequestUserInfo): AchievedBadgeResponse {
-        TODO("""
-            - 내가 얻은 뱃지 정보 가져오기
-        """.trimIndent())
+    fun getAchievedBadge(@RequestUser requestUser: RequestUserInfo): List<AchievedBadgeResponse> {
+        return memberService.getBadgeList(requestUser.userId)
     }
-
 
     @Operation(summary = "답변 활동기록 가져오기", description = "year, month를 통해 일별 답변활동 수 가져오기")
     @GetMapping("/answerGrass")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/controller/MemberController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/controller/MemberController.kt
@@ -53,10 +53,7 @@ class MemberController(
     @Operation(summary = "회원탈퇴", description = "유저 활동 기록도 지워짐 주의!")
     @DeleteMapping
     fun withdrawal(@RequestUser requestUser: RequestUserInfo): String {
-        TODO("""
-            - 회원탈퇴
-            - 어디까지 삭제해야하나?
-        """.trimIndent())
+        return authService.withdraw(requestUser.userId)
     }
 
     @Operation(summary = "출석", description = "앱 내 출석체크")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/controller/MemberController.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/controller/MemberController.kt
@@ -47,9 +47,7 @@ class MemberController(
         @RequestUser requestUser: RequestUserInfo,
         @PathVariable memberId: Long,
     ) : MemberProfileResponse {
-        TODO("""
-            - 특정 유저 정보 가져오기
-        """.trimIndent())
+        return memberService.getProfile(memberId)
     }
 
     @Operation(summary = "회원탈퇴", description = "유저 활동 기록도 지워짐 주의!")

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/dto/response/AchievedBadgeResponse.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/dto/response/AchievedBadgeResponse.kt
@@ -1,5 +1,7 @@
 package com.adevspoon.api.member.dto.response
 
+import com.adevspoon.domain.member.dto.response.BadgeAchievedInfo
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class AchievedBadgeResponse(
@@ -10,11 +12,28 @@ data class AchievedBadgeResponse(
     val thumbnailUrl: String,
     @Schema(description = "뱃지 실루엣 이미지")
     val silhouetteUrl: String,
+    @JsonProperty("isAcheived")
+    @Schema(description = "뱃지 획득 여부")
+    val isAchieved: Boolean,
     @Schema(description = "뱃지 획득을 위한 달성 기준 일수")
     val criteriaValue: Int?,
-    val isAcheived: Boolean,
-    @Schema(description = "뱃지 획득을 위한 현재 유저가 달성한 일수")
+    @Schema(description = "뱃지 획득을 위한 현재 유저가 달성한 수")
     val userValue: Int,
     @Schema(description = "현재 대표뱃지로 설정했는지 여부")
     val isRepresentative: Boolean,
-)
+) {
+    companion object {
+        fun from(badge: BadgeAchievedInfo) = AchievedBadgeResponse(
+            id = badge.id,
+            name = badge.name,
+            description = badge.description,
+            imageUrl = badge.imageUrl,
+            thumbnailUrl = badge.thumbnailUrl,
+            silhouetteUrl = badge.silhouetteUrl,
+            isAchieved = badge.isAchieved,
+            criteriaValue = badge.criteriaValue,
+            userValue = badge.userValue,
+            isRepresentative = badge.isRepresentative
+        )
+    }
+}

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/service/MemberService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/service/MemberService.kt
@@ -34,6 +34,11 @@ class MemberService(
         return MemberProfileResponse.from(memberProfile)
     }
 
+    fun attend(memberId: Long): MemberProfileResponse {
+        val memberProfile = memberDomainService.attend(memberId)
+        return MemberProfileResponse.from(memberProfile)
+    }
+
     fun getLikeList(memberId: Long, request: MemberFavoriteListRequest): MemberFavoriteListResponse {
         val likeList = memberDomainService.getLikeList(GetLikeList(memberId, request.startId, request.take))
 

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/service/MemberService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/service/MemberService.kt
@@ -5,6 +5,7 @@ import com.adevspoon.api.common.util.ImageProcessor
 import com.adevspoon.api.member.dto.request.MemberFavoriteListRequest
 import com.adevspoon.common.enums.ImageType
 import com.adevspoon.api.member.dto.request.MemberProfileUpdateRequest
+import com.adevspoon.api.member.dto.response.AchievedBadgeResponse
 import com.adevspoon.api.member.dto.response.MemberFavoriteListResponse
 import com.adevspoon.api.member.dto.response.MemberProfileResponse
 import com.adevspoon.domain.member.dto.request.GetLikeList
@@ -46,6 +47,11 @@ class MemberService(
             likeList.list,
             request.nextUrl(likeList.nextStartId)
         )
+    }
+
+    fun getBadgeList(memberId: Long): List<AchievedBadgeResponse> {
+        val badgeList = memberDomainService.getBadgeListWithAchievedInfo(memberId)
+        return badgeList.map { AchievedBadgeResponse.from(it) }
     }
 
     private fun uploadProfileImage(image: MultipartFile): List<String> {

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/service/MemberService.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/member/service/MemberService.kt
@@ -19,6 +19,11 @@ class MemberService(
     private val storageAdapter: StorageAdapter,
     private val imageProcessor: ImageProcessor
 ) {
+    fun getProfile(memberId: Long): MemberProfileResponse {
+        val memberProfile = memberDomainService.getMemberProfile(memberId)
+        return MemberProfileResponse.from(memberProfile)
+    }
+
     fun updateProfile(userId: Long, request: MemberProfileUpdateRequest): MemberProfileResponse {
         val (profileUrl, thumbnailUrl) = request.image
             ?.let(::uploadProfileImage)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/aop/ActivityEventAdvisor.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/common/aop/ActivityEventAdvisor.kt
@@ -5,7 +5,10 @@ import com.adevspoon.domain.board.exception.BoardPostInvalidReturnException
 import com.adevspoon.domain.common.annotation.ActivityEvent
 import com.adevspoon.domain.common.annotation.ActivityEventType
 import com.adevspoon.domain.common.event.AnswerActivityEvent
+import com.adevspoon.domain.common.event.AttendanceActivityEvent
 import com.adevspoon.domain.common.event.BoardPostActivityEvent
+import com.adevspoon.domain.member.dto.response.MemberProfile
+import com.adevspoon.domain.member.exception.MemberAttendanceInvalidReturnException
 import com.adevspoon.domain.techQuestion.dto.response.QuestionAnswerInfo
 import com.adevspoon.domain.techQuestion.exception.QuestionAnswerInvalidReturnException
 import org.aspectj.lang.JoinPoint
@@ -47,9 +50,10 @@ class ActivityEventAdvisor(
     }
 
     private fun attendanceEventPublish(result: Any?) {
-        TODO("""
-            Implement the logic to publish the ATTENDANCE event
-        """.trimIndent())
+        (result as? MemberProfile)
+            ?.let {
+                eventPublisher.publishEvent(AttendanceActivityEvent(it.memberId))
+            } ?: throw MemberAttendanceInvalidReturnException()
     }
 
     private fun answerEventPublish(result: Any?) {

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/AttendanceEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/AttendanceEntity.kt
@@ -16,9 +16,9 @@ class AttendanceEntity(
 class AttendanceId(
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "userId", nullable = false)
-    val user: UserEntity? = null,
+    val user: UserEntity,
 
     @NotNull
     @Column(name = "attendTime", nullable = false)
-    val attendTime: LocalDateTime? = null
+    val attendTime: LocalDateTime
 ): Serializable

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/UserActivityEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/UserActivityEntity.kt
@@ -73,4 +73,16 @@ class UserActivityEntity(
     @NotNull
     @Column(name = "answerClang", nullable = false)
     var answerClang: Int = 0
-): BaseEntity()
+): BaseEntity() {
+    fun fieldValue(fieldName: String): Int {
+        return when (fieldName) {
+            "cumulativeAnswerCount" -> cumulativeAnswerCount
+            "consecutiveAnswerCount" -> consecutiveAnswerCount
+            "cumulativeAttendanceCount" -> cumulativeAttendanceCount
+            "consecutiveAttendanceCount" -> consecutiveAttendanceCount
+            "maxConsecutiveAnswerCount" -> maxConsecutiveAnswerCount
+            "maxConsecutiveAttendanceCount" -> maxConsecutiveAttendanceCount
+            else -> 0
+        }
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/UserEntity.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/domain/UserEntity.kt
@@ -85,4 +85,10 @@ class UserEntity(
     fun increaseAnswerCnt() {
         answerCnt += 1
     }
+
+    fun withdraw() {
+        status = UserStatus.EXIT
+        refreshToken = null
+        fcmToken = null
+    }
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/dto/response/BadgeAchievedInfo.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/dto/response/BadgeAchievedInfo.kt
@@ -1,0 +1,37 @@
+package com.adevspoon.domain.member.dto.response
+
+import com.adevspoon.domain.member.domain.BadgeEntity
+
+
+data class BadgeAchievedInfo(
+    val id: Int,
+    val name: String,
+    val description: String,
+    val imageUrl: String,
+    val thumbnailUrl: String,
+    val silhouetteUrl: String,
+    val criteriaValue: Int?,
+    val userValue: Int,
+    val isAchieved: Boolean,
+    val isRepresentative: Boolean = false,
+) {
+    companion object {
+        fun from(
+            badge: BadgeEntity,
+            isAchieved: Boolean,
+            isRepresentative: Boolean,
+            userValue: Int,
+        ) = BadgeAchievedInfo(
+            id = badge.id,
+            name = badge.name ?: "",
+            description = badge.description ?: "",
+            imageUrl = badge.imageUrl ?: "",
+            thumbnailUrl = badge.thumbnailUrl ?: "",
+            silhouetteUrl = badge.silhouetteUrl ?: "",
+            criteriaValue = badge.criteriaValue,
+            userValue = userValue,
+            isAchieved = isAchieved,
+            isRepresentative = isRepresentative,
+        )
+    }
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainErrorCode.kt
@@ -8,6 +8,7 @@ enum class MemberDomainErrorCode(
     override val error: DomainType.Error,
     override val message: String,
 ): AdevspoonErrorCode {
+    MEMBER_ATTENDANCE_INVALID_RETURN(DomainType.MEMBER code 400 no 0, "출석 반환값이 잘못되었습니다"),
     MEMBER_ALREADY_EXPIRED_REFRESH_TOKEN(DomainType.MEMBER code 403 no 0, "이미 만료된 리프레시 토큰입니다"),
 
     MEMBER_NOT_FOUND(DomainType.MEMBER code 404 no 0, "등록되지 않은 유저입니다"),

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainErrorCode.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainErrorCode.kt
@@ -8,6 +8,8 @@ enum class MemberDomainErrorCode(
     override val error: DomainType.Error,
     override val message: String,
 ): AdevspoonErrorCode {
+    MEMBER_ALREADY_EXPIRED_REFRESH_TOKEN(DomainType.MEMBER code 403 no 0, "이미 만료된 리프레시 토큰입니다"),
+
     MEMBER_NOT_FOUND(DomainType.MEMBER code 404 no 0, "등록되지 않은 유저입니다"),
     MEMBER_BADGE_NOT_FOUND(DomainType.MEMBER code 404 no 1, "발급받지 않은 뱃지 등록");
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainException.kt
@@ -2,6 +2,7 @@ package com.adevspoon.domain.member.exception
 
 import com.adevspoon.common.exception.AdevspoonException
 
+class MemberAttendanceInvalidReturnException: AdevspoonException(MemberDomainErrorCode.MEMBER_ATTENDANCE_INVALID_RETURN)
 class MemberAlreadyExpiredRefreshTokenException: AdevspoonException(MemberDomainErrorCode.MEMBER_ALREADY_EXPIRED_REFRESH_TOKEN)
 class MemberNotFoundException: AdevspoonException(MemberDomainErrorCode.MEMBER_NOT_FOUND)
 class MemberBadgeNotFoundException: AdevspoonException(MemberDomainErrorCode.MEMBER_BADGE_NOT_FOUND)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainException.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/exception/MemberDomainException.kt
@@ -2,5 +2,6 @@ package com.adevspoon.domain.member.exception
 
 import com.adevspoon.common.exception.AdevspoonException
 
+class MemberAlreadyExpiredRefreshTokenException: AdevspoonException(MemberDomainErrorCode.MEMBER_ALREADY_EXPIRED_REFRESH_TOKEN)
 class MemberNotFoundException: AdevspoonException(MemberDomainErrorCode.MEMBER_NOT_FOUND)
 class MemberBadgeNotFoundException: AdevspoonException(MemberDomainErrorCode.MEMBER_BADGE_NOT_FOUND)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/repository/AttendanceRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/repository/AttendanceRepository.kt
@@ -1,0 +1,15 @@
+package com.adevspoon.domain.member.repository
+
+import com.adevspoon.domain.member.domain.AttendanceEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.sql.Date
+
+interface AttendanceRepository: JpaRepository<AttendanceEntity, Long> {
+    @Query("SELECT DATE(a.attendanceId.attendTime) " +
+            "FROM AttendanceEntity a " +
+            "WHERE a.attendanceId.user.id = :userId " +
+            "ORDER BY DATE(a.attendanceId.attendTime) DESC " +
+            "Limit 2")
+    fun findAttendanceDateList(userId: Long): List<Date>
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/repository/UserActivityRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/repository/UserActivityRepository.kt
@@ -13,6 +13,6 @@ interface UserActivityRepository : JpaRepository<UserActivityEntity, Long> {
     fun increaseBoardPostCount(userId: Long): Int
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT u FROM UserActivityEntity u WHERE u.id = :userid")
-    fun findByIdWithLock(userid: Long): UserActivityEntity?
+    @Query("SELECT u FROM UserActivityEntity u WHERE u.id = :userId")
+    fun findByIdWithLock(userId: Long): UserActivityEntity?
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
@@ -12,6 +12,7 @@ import com.adevspoon.domain.member.dto.response.LikeInfo
 import com.adevspoon.domain.member.dto.response.LikeListInfo
 import com.adevspoon.domain.member.dto.response.MemberAndSignup
 import com.adevspoon.domain.member.dto.response.MemberProfile
+import com.adevspoon.domain.member.exception.MemberAlreadyExpiredRefreshTokenException
 import com.adevspoon.domain.member.exception.MemberBadgeNotFoundException
 import com.adevspoon.domain.member.exception.MemberNotFoundException
 import com.adevspoon.domain.member.repository.BadgeRepository
@@ -105,11 +106,12 @@ class MemberDomainService(
     }
 
     @Transactional
-    fun updateMemberToken(userId: Long, refreshToken: String) {
+    fun checkAndUpdateToken(userId: Long, oldToken: String?, newToken: String) {
         val user = getUserEntity(userId)
-        user.apply {
-            this.refreshToken = refreshToken
-        }
+
+        if (oldToken != null && user.refreshToken != oldToken) throw MemberAlreadyExpiredRefreshTokenException()
+
+        user.apply { refreshToken = newToken }
     }
 
     @Transactional(readOnly = true)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/member/service/MemberDomainService.kt
@@ -10,6 +10,7 @@ import com.adevspoon.domain.member.domain.AttendanceId
 import com.adevspoon.domain.member.domain.UserActivityEntity
 import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.domain.enums.UserOAuth
+import com.adevspoon.domain.member.domain.enums.UserStatus
 import com.adevspoon.domain.member.dto.request.GetLikeList
 import com.adevspoon.domain.member.dto.request.MemberUpdateRequireDto
 import com.adevspoon.domain.member.dto.response.LikeInfo
@@ -94,6 +95,13 @@ class MemberDomainService(
         } catch (e: Exception) {
             throw e
         }
+    }
+
+    @Transactional
+    fun withdraw(memberId: Long) {
+        val member = getUserEntity(memberId)
+        if (member.status == UserStatus.EXIT) throw MemberNotFoundException()
+        member.withdraw()
     }
 
     @Transactional


### PR DESCRIPTION

### Issue
- close #83

### Summary
- 토큰 재발급 API
- 유저 정보 API
- 출석 API(및 이벤트 처리)
- 회원탈퇴 API
- 획득한 뱃지 리스트 API

### Description
- 크게 복잡한 로직이 아니라 한 번에 작성했습니다.