### PR TITLE
Feat/#75. 커서 페이징 기반 게시판 가져오기 수정

### DIFF
--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/request/BoardListRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/request/BoardListRequest.kt
@@ -6,19 +6,19 @@ import jakarta.validation.constraints.Positive
 
 data class BoardListRequest(
     @Schema(description = "게시글 태그로 필터링 - 선택한 태그들의 id를 배열로 전달, 비어있다면 태그로 필터링 하지 않음", example = "[1, 2, 3]", nullable = true, defaultValue = "[]")
-    val tag: List<Int>,
+    val tag: List<Int>? = emptyList(),
     @Schema(description = "가져올 게시글 갯수", nullable = true, defaultValue = "10")
     @field:Positive(message = "0보다 큰 수를 입력해주세요")
-    val take: Int = 10,
-    @Schema(description = "가져올 게시글 시작 Id(이 Id보다 작은 Id의 게시글들을 가져옴), null이면 가장 최신데이터부턱 가져옴", nullable = true, defaultValue = "0")
+    val take: Int? = 10,
+    @Schema(description = "가져올 게시글 시작 Id(이 Id보다 작은 Id의 게시글들을 가져옴), null이면 가장 최신데이터부턱 가져옴", nullable = true, defaultValue = "null")
     @field:Positive(message = "0보다 큰 수를 입력해주세요")
     val startId: Long? = null,
     @Schema(description = "유저 Id(게시글 작성자 Id)로 필터링", nullable = true, defaultValue = "null")
-    val userId: Long?
+    val userId: Long? = null
 ) {
     fun toGetPostListRequestDto() = GetPostListRequestDto(
         tags = this.tag,
-        pageSize = this.take,
+        pageSize = this.take ?: 10,
         startPostId = this.startId,
         targetUserId = this.userId
     )

--- a/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/request/BoardListRequest.kt
+++ b/adevspoon-api/src/main/kotlin/com/adevspoon/api/board/dto/request/BoardListRequest.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Positive
 
 data class BoardListRequest(
     @Schema(description = "게시글 태그로 필터링 - 선택한 태그들의 id를 배열로 전달, 비어있다면 태그로 필터링 하지 않음", example = "[1, 2, 3]", nullable = true, defaultValue = "[]")
-    val tag: List<Int>? = emptyList(),
+    val tag: List<Int> = emptyList(),
     @Schema(description = "가져올 게시글 갯수", nullable = true, defaultValue = "10")
     @field:Positive(message = "0보다 큰 수를 입력해주세요")
     val take: Int? = 10,

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/dto/request/GetPostListRequestDto.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/dto/request/GetPostListRequestDto.kt
@@ -1,8 +1,8 @@
 package com.adevspoon.domain.board.dto.request
 
 data class GetPostListRequestDto(
-    val tags: List<Int>,
+    val tags: List<Int>?,
     val pageSize: Int = 10,
-    val startPostId: Long? = null,
+    val startPostId: Long?,
     val targetUserId: Long?
 )

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
@@ -1,8 +1,8 @@
 package com.adevspoon.domain.board.repository
 
 import com.adevspoon.domain.board.domain.BoardPostEntity
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -16,7 +16,7 @@ interface BoardPostRepository : JpaRepository<BoardPostEntity, Long> {
     fun findWithNoTagsAndUserIdWithCursor(
         @Param("startPostId") startPostId: Long?,
         @Param("targetUserId") targetUserId: Long?,
-        pageable: Pageable) : Page<BoardPostEntity>
+        pageable: Pageable) : Slice<BoardPostEntity>
 
     @Query("SELECT bp FROM BoardPostEntity bp " +
         "JOIN bp.tag t " +
@@ -28,5 +28,5 @@ interface BoardPostRepository : JpaRepository<BoardPostEntity, Long> {
         @Param("tags") tags: List<Int>,
         @Param("startPostId") startPostId: Long?,
         @Param("targetUserId") targetUserId: Long?,
-        pageable: Pageable): Page<BoardPostEntity>
+        pageable: Pageable): Slice<BoardPostEntity>
 }

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
@@ -1,32 +1,6 @@
 package com.adevspoon.domain.board.repository
 
 import com.adevspoon.domain.board.domain.BoardPostEntity
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
-interface BoardPostRepository : JpaRepository<BoardPostEntity, Long> {
-
-    @Query("SELECT bp FROM BoardPostEntity bp " +
-        "WHERE (:startPostId IS NULL OR bp.id < :startPostId) " +
-        "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId)"
-    )
-    fun findWithNoTagsAndUserIdWithCursor(
-        @Param("startPostId") startPostId: Long?,
-        @Param("targetUserId") targetUserId: Long?,
-        pageable: Pageable) : Slice<BoardPostEntity>
-
-    @Query("SELECT bp FROM BoardPostEntity bp " +
-        "JOIN bp.tag t " +
-        "WHERE (t.id IN :tags) " +
-        "AND (:startPostId IS NULL OR bp.id < :startPostId) " +
-        "AND (:targetUserId IS NULL OR bp.user.id = :targetUserId) "
-        )
-    fun findByTagsAndUserIdWithCursor(
-        @Param("tags") tags: List<Int>,
-        @Param("startPostId") startPostId: Long?,
-        @Param("targetUserId") targetUserId: Long?,
-        pageable: Pageable): Slice<BoardPostEntity>
-}
+interface BoardPostRepository : JpaRepository<BoardPostEntity, Long>

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepository.kt
@@ -3,4 +3,4 @@ package com.adevspoon.domain.board.repository
 import com.adevspoon.domain.board.domain.BoardPostEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface BoardPostRepository : JpaRepository<BoardPostEntity, Long>
+interface BoardPostRepository : JpaRepository<BoardPostEntity, Long>, BoardPostRepositoryCustom

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepositoryCustom.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepositoryCustom.kt
@@ -1,0 +1,9 @@
+package com.adevspoon.domain.board.repository
+
+import com.adevspoon.domain.board.domain.BoardPostEntity
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+interface BoardPostRepositoryCustom {
+    fun findByTagsAndUserIdWithCursor(tags: List<Int>?, startPostId: Long?, targetUserId: Long?, pageable: Pageable): Slice<BoardPostEntity>
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepositoryCustomImpl.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepositoryCustomImpl.kt
@@ -1,0 +1,55 @@
+package com.adevspoon.domain.board.repository
+
+import com.adevspoon.domain.board.domain.BoardPostEntity
+import com.adevspoon.domain.board.domain.QBoardPostEntity.boardPostEntity
+import com.adevspoon.domain.board.domain.QBoardTagEntity.boardTagEntity
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.stereotype.Repository
+
+@Repository
+class BoardPostRepositoryCustomImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : BoardPostRepositoryCustom {
+    override fun findByTagsAndUserIdWithCursor(
+        tags: List<Int>?,
+        startPostId: Long?,
+        targetUserId: Long?,
+        pageable: Pageable
+    ): Slice<BoardPostEntity> {
+        val boardPosts = jpaQueryFactory.selectFrom(boardPostEntity)
+            .apply {
+                if (!tags.isNullOrEmpty()) {
+                    join(boardPostEntity.tag, boardTagEntity)
+                        .where(boardTagEntity.id.`in`(tags))
+                } else {
+                    jpaQueryFactory.selectFrom(boardTagEntity).fetch()
+                }
+            }
+            .where(
+                userIdCondition(targetUserId),
+                postIdLessThanCondition(startPostId)
+            )
+            .orderBy(boardPostEntity.id.desc())
+            .limit((pageable.pageSize.toLong() + 1))
+            .fetch()
+
+        val hasNext = boardPosts.size > pageable.pageSize
+        val sliceContent = if (hasNext) boardPosts.subList(0, pageable.pageSize) else boardPosts
+
+        return SliceImpl(sliceContent, pageable, hasNext)
+    }
+
+    private fun userIdCondition(userId: Long?): BooleanExpression? {
+        return userId?.let { boardPostEntity.user.id.eq(it) }
+    }
+
+    private fun postIdLessThanCondition(postId: Long?): BooleanExpression? {
+        return postId?.let { boardPostEntity.id.lt(it) }
+    }
+
+
+}

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepositoryCustomImpl.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/repository/BoardPostRepositoryCustomImpl.kt
@@ -8,9 +8,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.domain.SliceImpl
-import org.springframework.stereotype.Repository
 
-@Repository
+
 class BoardPostRepositoryCustomImpl(
     private val jpaQueryFactory: JPAQueryFactory
 ) : BoardPostRepositoryCustom {
@@ -21,14 +20,7 @@ class BoardPostRepositoryCustomImpl(
         pageable: Pageable
     ): Slice<BoardPostEntity> {
         val boardPosts = jpaQueryFactory.selectFrom(boardPostEntity)
-            .apply {
-                if (!tags.isNullOrEmpty()) {
-                    join(boardPostEntity.tag, boardTagEntity)
-                        .where(boardTagEntity.id.`in`(tags))
-                } else {
-                    jpaQueryFactory.selectFrom(boardTagEntity).fetch()
-                }
-            }
+            .leftJoin(boardPostEntity.tag, boardTagEntity).fetchJoin()
             .where(
                 userIdCondition(targetUserId),
                 postIdLessThanCondition(startPostId)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
@@ -117,8 +117,8 @@ class BoardPostDomainService(
         return likeDomainService.getLikedPostIdsByUser(loginUserId, postIds).toSet()
     }
 
-    private fun fetchPostBasedOnTageExistence(tags: List<Int>, startPostId: Long?, targetUserId: Long?, pageable: Pageable): Page<BoardPostEntity> {
-        if (tags.isEmpty()) {
+    private fun fetchPostBasedOnTageExistence(tags: List<Int>?, startPostId: Long?, targetUserId: Long?, pageable: Pageable): Page<BoardPostEntity> {
+        if (tags.isNullOrEmpty()) {
             return retrievePostsIfNoTags(startPostId, targetUserId, pageable)
         }
         return retrievePostsByTagsIfPresent(tags, startPostId, targetUserId, pageable)

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
@@ -23,8 +23,6 @@ import com.adevspoon.domain.member.domain.UserEntity
 import com.adevspoon.domain.member.exception.MemberNotFoundException
 import com.adevspoon.domain.member.repository.UserRepository
 import com.adevspoon.domain.member.service.MemberDomainService
-import org.springframework.data.domain.Pageable
-import org.springframework.data.domain.Slice
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -117,21 +115,6 @@ class BoardPostDomainService(
 
     private fun getLikedPostsByUser(loginUserId: Long, postIds: List<Long>): Set<Long> {
         return likeDomainService.getLikedPostIdsByUser(loginUserId, postIds).toSet()
-    }
-
-    private fun fetchPostBasedOnTageExistence(tags: List<Int>?, startPostId: Long?, targetUserId: Long?, pageable: Pageable): Slice<BoardPostEntity> {
-        if (tags.isNullOrEmpty()) {
-            return retrievePostsIfNoTags(startPostId, targetUserId, pageable)
-        }
-        return retrievePostsByTagsIfPresent(tags, startPostId, targetUserId, pageable)
-    }
-
-    private fun retrievePostsIfNoTags(startPostId: Long?, targetUserId: Long?, pageable: Pageable): Slice<BoardPostEntity> {
-        return boardPostRepository.findWithNoTagsAndUserIdWithCursor(startPostId, targetUserId, pageable)
-    }
-
-    private fun retrievePostsByTagsIfPresent(tags: List<Int>, startPostId: Long?, targetUserId: Long?, pageable: Pageable): Slice<BoardPostEntity> {
-        return boardPostRepository.findByTagsAndUserIdWithCursor(tags, startPostId, targetUserId, pageable)
     }
 
     @Transactional

--- a/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
+++ b/adevspoon-domain/src/main/kotlin/com/adevspoon/domain/board/service/BoardPostDomainService.kt
@@ -7,7 +7,6 @@ import com.adevspoon.domain.board.dto.response.BoardPost
 import com.adevspoon.domain.board.exception.*
 import com.adevspoon.domain.board.repository.BoardCommentRepository
 import com.adevspoon.domain.board.repository.BoardPostRepository
-import com.adevspoon.domain.board.repository.BoardPostRepositoryCustom
 import com.adevspoon.domain.board.repository.BoardTagRepository
 import com.adevspoon.domain.common.annotation.ActivityEvent
 import com.adevspoon.domain.common.annotation.ActivityEventType
@@ -30,7 +29,6 @@ import java.util.*
 @DomainService
 class BoardPostDomainService(
     val boardPostRepository: BoardPostRepository,
-    val boardPostRepositoryCustom: BoardPostRepositoryCustom,
     val boardTagRepository: BoardTagRepository,
     val boardCommentRepository: BoardCommentRepository,
     val reportRepository: ReportRepository,
@@ -97,7 +95,7 @@ class BoardPostDomainService(
     @Transactional(readOnly = true)
     fun getBoardPostsWithCriteria(request: GetPostListRequestDto, loginUserId: Long): PageWithCursor<BoardPost> {
         val pageable = CursorPageable(request.pageSize)
-        val postsSlice = boardPostRepositoryCustom.findByTagsAndUserIdWithCursor(request.tags, request.startPostId, request.targetUserId, pageable)
+        val postsSlice = boardPostRepository.findByTagsAndUserIdWithCursor(request.tags, request.startPostId, request.targetUserId, pageable)
 
         val boardPosts = postsSlice.content
         val nextCursorId = if (!postsSlice.hasNext()) null else boardPosts.lastOrNull()?.id


### PR DESCRIPTION
PR 타이틀 형식 - Feat#{이슈번호}. 내용

### Issue
 
- close #75 
- close #77 

### Summary
- tag, take, startId, userId 모두 null 허용
- tag가 null or empty 일 경우 태그 데이터 상관없이 게시판 데이터 가져오기
- take가 null일 경우 10으로 변경
- pageSize = limit 같을 경우 next cursorId 가져오지 않는 문제 해결

### Description
- QueryDSL로 동적쿼리를 만들어 하나의 메서드로 통일시켰습니다.
- 레포지토리에서 응답을 Page에서 Slice변경했습니다.